### PR TITLE
feat(file-uploader): disabled-with-hint Remove BG toggle + upload button state fix

### DIFF
--- a/docs/live/image-processing/technical-guide.md
+++ b/docs/live/image-processing/technical-guide.md
@@ -1,12 +1,14 @@
 # FileUploader Image Processing — Technical Guide
 
-**Last Updated**: 2026-04-07
+**Last Updated**: 2026-04-06
 
 ## Overview
 
 Extends Frappe's FileUploader with two opt-in image processing features:
 1. **Remove Background** — server-side AI background removal with live preview toggle
-2. **Watermark Overlay** — configurable logo overlay with drag/resize in a dedicated mode
+2. **Watermark Overlay** — configurable logo overlay with two modes:
+   - **Corner** — single logo at a configurable position with drag/resize
+   - **Tiled** — repeated logo grid across the entire image with rotation and spacing
 
 Both features are generic framework extensions — the actual processing logic (rembg API, watermark settings) is provided by the calling app (pps190/next).
 
@@ -16,25 +18,31 @@ Both features are generic framework extensions — the actual processing logic (
 
 ```
 FileUploader (index.js)
-  ├── Dialog footer toggles (add_footer_toggle)
-  │   ├── Remove Background toggle
-  │   └── Watermark toggle (disabled with config link when no settings)
-  │
-  └── FileUploader.vue
-        ├── Props: show_remove_bg, remove_bg_default, show_watermark, watermark_settings
-        ├── Data: remove_bg_checked, wm_enabled
-        │
-        ├── FilePreview.vue
-        │     └── Watches file.file_obj → re-reads thumbnail
-        │
-        └── ImageCropper.vue
-              ├── Mode switcher: [Crop] [Watermark] segmented tabs
-              ├── Crop mode: CropperJS handles all interactions
-              ├── Watermark mode: canvas overlay intercepts events
-              ├── Remove BG: upload temp → call API → swap file
-              ├── Watermark canvas: pointer-events toggled by mode
-              ├── Control panel: Position X/Y, Size, Opacity + Save/Reset
-              └── Crop composites watermark onto final canvas
+  |-- Dialog footer toggles (add_footer_toggle)
+  |   |-- Remove Background toggle
+  |   +-- Watermark toggle (disabled with config link when no settings)
+  |
+  +-- FileUploader.vue
+        |-- Props: show_remove_bg, remove_bg_default, show_watermark, watermark_settings
+        |-- Data: remove_bg_checked, wm_enabled
+        |
+        |-- FilePreview.vue
+        |     +-- Watches file.file_obj -> re-reads thumbnail
+        |
+        +-- ImageCropper.vue
+              |-- Mode switcher: [Crop] [Watermark] segmented tabs
+              |-- Crop mode: CropperJS handles all interactions
+              |-- Watermark mode: canvas overlay intercepts events
+              |     |-- Corner/Tiled mode selector in control panel
+              |     |-- Corner: drag to move, scroll to resize single logo
+              |     +-- Tiled: rotated grid of logos across entire image
+              |-- Remove BG: upload temp -> call API -> swap file
+              |-- Watermark canvas: pointer-events toggled by mode
+              |-- Control panel:
+              |     |-- Corner: Opacity slider + Size slider + numeric inputs
+              |     |-- Tiled: Opacity + Tile Size + Rotation + Spacing sliders + numeric inputs
+              |     +-- Save as Default / Reset buttons
+              +-- Crop composites watermark onto final canvas
 ```
 
 ### Mode switcher
@@ -44,29 +52,64 @@ The `[Crop | Watermark]` segmented control above the image determines which tool
 | Mode | CropperJS | Watermark Canvas | User Action |
 |------|-----------|-----------------|-------------|
 | Crop | `setDragMode("crop")` | `pointer-events: none` | Drag/resize crop area |
-| Watermark | `setDragMode("none")` | `pointer-events: auto` | Drag watermark, scroll to resize |
+| Watermark | `setDragMode("none")` | `pointer-events: auto` | Interact with watermark |
 
 The Watermark tab is disabled (grayed out, not clickable) when the Watermark toggle is off. Turning off the Watermark toggle auto-switches to Crop mode.
+
+### Watermark mode — Corner/Tiled selector
+
+Within Watermark mode, the control panel includes a Corner/Tiled mode selector:
+
+| Watermark Mode | Canvas Behavior | User Action |
+|----------------|----------------|-------------|
+| Corner | Single logo drawn at position | Drag to move, scroll to resize |
+| Tiled | Rotated grid of logos across image | Adjust via sliders only (no drag) |
 
 ### Coordinate system
 
 Watermark position percentages are relative to the **image display area** within the CropperJS container, obtained via `cropper.getCanvasData()`:
 
+**Corner mode:**
 - **Preview draw**: `x = cd.left + (pos_x/100) * cd.width - wm_w/2`
 - **Hit test**: same coordinate space
 - **Drag update**: `pos_x = ((mx - offset - cd.left) / cd.width) * 100`
 - **Crop composite**: convert from `(pos_x/100) * naturalWidth` pixel space, subtract crop box offset, scale to output canvas
 
+**Tiled mode:**
+- **Preview draw**: `wm_draw_tiled()` rotates canvas by `tile_rotation`, draws logo grid with spacing
+- **Crop composite**: applies same rotation and grid calculation in pixel space, mapping each tile through crop box offset and scale
+
 This ensures the watermark appears in exactly the same position in preview and final output regardless of image scaling or crop box position.
+
+### Tiled rendering
+
+The `wm_draw_tiled()` method:
+
+1. Saves canvas state
+2. Translates to image center (from `getCanvasData()`)
+3. Rotates by `tile_rotation` degrees
+4. Calculates tile dimensions: `tile_w = (tile_size/100) * cd.width`
+5. Calculates spacing: `gap = (tile_spacing/100) * tile_w`
+6. Draws logos in a grid covering the rotated bounding box
+7. Restores canvas state
+
+For the crop composite, `crop_image` performs the same calculation in natural pixel coordinates, iterating over the grid and drawing each tile onto the output canvas.
 
 ### Collapsible control panel
 
-When watermark is enabled, a `<transition name="wm-panel">` panel slides down between the image and the action buttons:
+When watermark is enabled, a `<transition name="wm-panel">` panel slides down between the image and the action buttons. The panel content changes based on the watermark mode:
 
+**Corner mode:**
 - **2-column grid**: Position X, Position Y, Size, Opacity numeric inputs
-- **Full-width slider**: Opacity range input
-- **Action buttons**: Reset (restore saved defaults), Save as Default (persist via `frappe.client.set_value`)
-- **Mobile**: single column at ≤576px, full-width buttons
+- **Sliders**: Opacity slider and Size slider
+- **Action buttons**: Reset, Save as Default
+
+**Tiled mode:**
+- **2-column grid**: Tile Size, Tile Opacity, Rotation, Spacing numeric inputs
+- **Sliders**: Opacity, Tile Size, Rotation, Spacing sliders
+- **Action buttons**: Reset, Save as Default
+
+**Mobile**: single column at <=576px, full-width buttons
 
 ### Footer toggles
 
@@ -88,13 +131,54 @@ The `file` object carries cached versions for instant toggle switching:
 | `file.file_obj` | Current active file (swapped by Vue `$set`) |
 | `file.cropper_file` | File for CropperJS (swapped on toggle) |
 
+## Key data properties and methods
+
+### Data properties (ImageCropper)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `wm_mode` | String | Current watermark mode: `"corner"` or `"tiled"` |
+| `wm_pos_x`, `wm_pos_y` | Number | Corner mode position (0-100%) |
+| `wm_size` | Number | Corner mode logo size (5-100%) |
+| `wm_opacity` | Number | Corner mode opacity (5-100%) |
+| `wm_tile_size` | Number | Tiled mode tile size (5-100%) |
+| `wm_tile_opacity` | Number | Tiled mode opacity (5-100%, default 12%) |
+| `wm_tile_rotation` | Number | Tiled mode rotation (-180 to +180 degrees) |
+| `wm_tile_spacing` | Number | Tiled mode spacing (0-100%) |
+
+### Methods (ImageCropper)
+
+| Method | Description |
+|--------|-------------|
+| `wm_set_mode(mode)` | Switch between `"corner"` and `"tiled"`, redraws canvas |
+| `wm_draw()` | Dispatches to `wm_draw_corner()` or `wm_draw_tiled()` based on `wm_mode` |
+| `wm_draw_corner()` | Draws single logo at position with opacity |
+| `wm_draw_tiled()` | Draws rotated grid of logos across image |
+| `wm_set_tile_size(val)` | Update tile size and redraw |
+| `wm_set_tile_opacity(val)` | Update tile opacity and redraw |
+| `wm_set_tile_rotation(val)` | Update rotation angle and redraw |
+| `wm_set_tile_spacing(val)` | Update spacing and redraw |
+| `wm_save_defaults()` | Persist mode + all params via `frappe.client.set_value` |
+| `wm_reset_defaults()` | Restore from `watermark_settings` prop |
+
+### Save/Reset
+
+**Save as Default** persists all parameters to Watermark Settings:
+- `mode` (Corner/Tiled)
+- Corner: `position_x`, `position_y`, `size`, `opacity`
+- Tiled: `tile_size`, `tile_opacity`, `tile_rotation`, `tile_spacing`
+
+**Reset** restores all parameters from the `watermark_settings` prop passed at initialization.
+
+Both operations also update `frappe._watermark_settings_cache` for the current session.
+
 ## Key files
 
 | File | Changes |
 |------|---------|
 | `frappe/.../file_uploader/index.js` | Constructor params, `add_footer_toggle()`, disabled state with config link |
 | `frappe/.../file_uploader/FileUploader.vue` | Props, `wm_enabled` data, `remove_bg_checked` file-swap watcher, footer toggle CSS |
-| `frappe/.../file_uploader/ImageCropper.vue` | Mode switcher, watermark canvas, control panel, coordinate conversion, Remove BG, Save/Reset defaults |
+| `frappe/.../file_uploader/ImageCropper.vue` | Mode switcher, Corner/Tiled selector, watermark canvas, control panel with mode-specific sliders, coordinate conversion, tiled grid rendering, Remove BG, Save/Reset defaults |
 | `frappe/.../file_uploader/FilePreview.vue` | `file.file_obj` watcher for reactive thumbnail |
 
 ## Integration guide
@@ -114,8 +198,13 @@ image_field.set_upload_options = function () {
     image_field.upload_options.watermark_settings = {
         enabled: true,
         watermark_image: "/files/logo.png",
+        mode: "Tiled",
+        // Corner params
         position_x: 80, position_y: 90,
         size: 20, opacity: 50,
+        // Tiled params
+        tile_size: 20, tile_opacity: 12,
+        tile_rotation: 0, tile_spacing: 50,
     };
 };
 ```
@@ -129,6 +218,7 @@ image_field.set_upload_options = function () {
 | `.wm-controls-panel` | Control panel | Collapsible panel with transition |
 | `.wm-controls-grid` | Input grid | 2-column on desktop, 1-column on mobile |
 | `.wm-input-group` | Input wrapper | Styled number input with % suffix |
+| `.wm-mode-selector` | Corner/Tiled selector | Mode toggle within control panel |
 | `.toggle-pill` / `.toggle-pill.active` | Cropper toggles | Remove BG and Watermark pills |
 | `.footer-toggle` / `.footer-toggle-pill` | Footer toggles | Dialog footer toggle pills |
 | `.footer-toggle-pill.disabled` | Disabled state | Dashed border, reduced opacity |

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -218,7 +218,7 @@
 			v-if="show_image_cropper && wrapper_ready"
 			:file="files[crop_image_with_index]"
 			:fixed_aspect_ratio="restrictions.crop_image_aspect_ratio"
-			:show_remove_bg="show_remove_bg"
+			:show_remove_bg="show_remove_bg && !remove_bg_disabled_hint"
 			:remove_bg_checked="remove_bg_checked"
 			:show_watermark="show_watermark"
 			:watermark_settings="watermark_settings"
@@ -300,6 +300,9 @@ export default {
 		remove_bg_default: {
 			default: true,
 		},
+		remove_bg_disabled_hint: {
+			default: null,
+		},
 		show_watermark: {
 			default: false,
 		},
@@ -331,7 +334,7 @@ export default {
 				enabled: false,
 			},
 			wrapper_ready: false,
-			remove_bg_checked: this.remove_bg_default,
+			remove_bg_checked: this.remove_bg_default && !this.remove_bg_disabled_hint,
 			wm_enabled: this.watermark_settings && this.watermark_settings.enabled ? true : false,
 		};
 	},

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -550,9 +550,13 @@ export default {
 			if (this.as_dataurl) {
 				return this.return_as_dataurl();
 			}
-			return frappe.run_serially(
-				this.files.map((file, i) => () => this.upload_file(file, i))
-			);
+			return frappe
+				.run_serially(this.files.map((file, i) => () => this.upload_file(file, i)))
+				.finally(() => {
+					// Reset upload state so the primary button re-enables when
+					// any upload ends (success that didn't auto-close, or error).
+					this.currently_uploading = -1;
+				});
 		},
 		upload_via_file_browser() {
 			let selected_file = this.$refs.file_browser.selected_node;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -45,60 +45,132 @@
 		<!-- Watermark control panel (collapsible) -->
 		<transition name="wm-panel">
 			<div v-if="wm_enabled && wm_loaded" class="wm-controls-panel">
-				<div class="wm-controls-grid">
-					<div class="wm-control-field">
-						<label class="wm-control-label">{{ __("Position X") }}</label>
-						<div class="wm-input-group">
-							<input type="number" class="wm-input"
-								:value="Math.round(wm_pos_x * 10) / 10"
-								min="0" max="100" step="0.5"
-								@input="wm_set_pos_x(parseFloat($event.target.value))"
-							/>
-							<span class="wm-input-suffix">%</span>
+				<!-- Mode selector -->
+				<div class="wm-mode-selector">
+					<button class="wm-mode-btn" :class="{ active: wm_mode === 'Corner' }" @click="wm_set_mode('Corner')">
+						{{ __("Corner") }}
+					</button>
+					<button class="wm-mode-btn" :class="{ active: wm_mode === 'Tiled' }" @click="wm_set_mode('Tiled')">
+						{{ __("Tiled") }}
+					</button>
+				</div>
+
+				<!-- Corner mode controls -->
+				<template v-if="wm_mode === 'Corner'">
+					<div class="wm-controls-grid">
+						<div class="wm-control-field">
+							<label class="wm-control-label">{{ __("Position X") }}</label>
+							<div class="wm-input-group">
+								<input type="number" class="wm-input"
+									:value="Math.round(wm_pos_x * 10) / 10"
+									min="0" max="100" step="0.5"
+									@input="wm_set_pos_x(parseFloat($event.target.value))"
+								/>
+								<span class="wm-input-suffix">%</span>
+							</div>
+						</div>
+						<div class="wm-control-field">
+							<label class="wm-control-label">{{ __("Position Y") }}</label>
+							<div class="wm-input-group">
+								<input type="number" class="wm-input"
+									:value="Math.round(wm_pos_y * 10) / 10"
+									min="0" max="100" step="0.5"
+									@input="wm_set_pos_y(parseFloat($event.target.value))"
+								/>
+								<span class="wm-input-suffix">%</span>
+							</div>
+						</div>
+						<div class="wm-control-field">
+							<label class="wm-control-label">{{ __("Size") }}</label>
+							<div class="wm-input-group">
+								<input type="number" class="wm-input"
+									:value="Math.round(wm_size * 10) / 10"
+									min="5" max="100" step="1"
+									@input="wm_set_size(parseFloat($event.target.value))"
+								/>
+								<span class="wm-input-suffix">%</span>
+							</div>
+						</div>
+						<div class="wm-control-field">
+							<label class="wm-control-label">{{ __("Opacity") }}</label>
+							<div class="wm-input-group">
+								<input type="number" class="wm-input"
+									:value="wm_opacity"
+									min="5" max="100" step="1"
+									@input="wm_set_opacity(parseInt($event.target.value))"
+								/>
+								<span class="wm-input-suffix">%</span>
+							</div>
 						</div>
 					</div>
-					<div class="wm-control-field">
-						<label class="wm-control-label">{{ __("Position Y") }}</label>
-						<div class="wm-input-group">
-							<input type="number" class="wm-input"
-								:value="Math.round(wm_pos_y * 10) / 10"
-								min="0" max="100" step="0.5"
-								@input="wm_set_pos_y(parseFloat($event.target.value))"
-							/>
-							<span class="wm-input-suffix">%</span>
-						</div>
-					</div>
-					<div class="wm-control-field">
-						<label class="wm-control-label">{{ __("Size") }}</label>
-						<div class="wm-input-group">
-							<input type="number" class="wm-input"
-								:value="Math.round(wm_size * 10) / 10"
-								min="5" max="100" step="1"
-								@input="wm_set_size(parseFloat($event.target.value))"
-							/>
-							<span class="wm-input-suffix">%</span>
-						</div>
-					</div>
-					<div class="wm-control-field">
+					<div class="wm-opacity-row">
 						<label class="wm-control-label">{{ __("Opacity") }}</label>
-						<div class="wm-input-group">
-							<input type="number" class="wm-input"
-								:value="wm_opacity"
-								min="5" max="100" step="1"
-								@input="wm_set_opacity(parseInt($event.target.value))"
-							/>
-							<span class="wm-input-suffix">%</span>
+						<input type="range" class="wm-slider" min="5" max="100"
+							:value="wm_opacity"
+							@input="wm_set_opacity(parseInt($event.target.value))"
+						/>
+						<span class="wm-slider-value">{{ wm_opacity }}%</span>
+					</div>
+				</template>
+
+				<!-- Tiled mode controls -->
+				<template v-if="wm_mode === 'Tiled'">
+					<div class="wm-controls-grid">
+						<div class="wm-control-field">
+							<label class="wm-control-label">{{ __("Tile Size") }}</label>
+							<div class="wm-input-group">
+								<input type="number" class="wm-input"
+									:value="Math.round(wm_tile_size)"
+									min="5" max="50" step="1"
+									@input="wm_set_tile_size(parseInt($event.target.value))"
+								/>
+								<span class="wm-input-suffix">%</span>
+							</div>
+						</div>
+						<div class="wm-control-field">
+							<label class="wm-control-label">{{ __("Opacity") }}</label>
+							<div class="wm-input-group">
+								<input type="number" class="wm-input"
+									:value="wm_tile_opacity"
+									min="5" max="100" step="1"
+									@input="wm_set_tile_opacity(parseInt($event.target.value))"
+								/>
+								<span class="wm-input-suffix">%</span>
+							</div>
+						</div>
+						<div class="wm-control-field">
+							<label class="wm-control-label">{{ __("Rotation") }}</label>
+							<div class="wm-input-group">
+								<input type="number" class="wm-input"
+									:value="wm_tile_rotation"
+									min="-60" max="0" step="1"
+									@input="wm_set_tile_rotation(parseInt($event.target.value))"
+								/>
+								<span class="wm-input-suffix">°</span>
+							</div>
+						</div>
+						<div class="wm-control-field">
+							<label class="wm-control-label">{{ __("Spacing") }}</label>
+							<div class="wm-input-group">
+								<input type="number" class="wm-input"
+									:value="wm_tile_spacing"
+									min="10" max="80" step="1"
+									@input="wm_set_tile_spacing(parseInt($event.target.value))"
+								/>
+								<span class="wm-input-suffix">%</span>
+							</div>
 						</div>
 					</div>
-				</div>
-				<div class="wm-opacity-row">
-					<label class="wm-control-label">{{ __("Opacity") }}</label>
-					<input type="range" class="wm-slider" min="5" max="100"
-						:value="wm_opacity"
-						@input="wm_set_opacity(parseInt($event.target.value))"
-					/>
-					<span class="wm-slider-value">{{ wm_opacity }}%</span>
-				</div>
+					<div class="wm-opacity-row">
+						<label class="wm-control-label">{{ __("Opacity") }}</label>
+						<input type="range" class="wm-slider" min="5" max="100"
+							:value="wm_tile_opacity"
+							@input="wm_set_tile_opacity(parseInt($event.target.value))"
+						/>
+						<span class="wm-slider-value">{{ wm_tile_opacity }}%</span>
+					</div>
+				</template>
+
 				<div class="wm-panel-actions">
 					<button class="btn btn-xs btn-default" @click="wm_reset_defaults">
 						{{ __("Reset") }}
@@ -202,6 +274,12 @@ export default {
 			wm_dragging: false,
 			wm_drag_offset_x: 0,
 			wm_drag_offset_y: 0,
+			wm_mode: "Corner",
+			// Tiled mode params
+			wm_tile_size: 15,
+			wm_tile_opacity: 20,
+			wm_tile_rotation: -30,
+			wm_tile_spacing: 40,
 			// Interaction mode
 			interaction_mode: "crop",
 		};
@@ -232,10 +310,17 @@ export default {
 		// Watermark: load settings
 		if (this.show_watermark && this.watermark_settings) {
 			this.wm_enabled = this.wm_default_enabled;
+			this.wm_mode = this.watermark_settings.mode || "Corner";
+			// Corner params
 			this.wm_pos_x = this.watermark_settings.position_x || 80;
 			this.wm_pos_y = this.watermark_settings.position_y || 90;
 			this.wm_size = this.watermark_settings.size || 20;
 			this.wm_opacity = this.watermark_settings.opacity || 50;
+			// Tiled params
+			this.wm_tile_size = this.watermark_settings.tile_size || 15;
+			this.wm_tile_opacity = this.watermark_settings.tile_opacity || 20;
+			this.wm_tile_rotation = this.watermark_settings.tile_rotation != null ? this.watermark_settings.tile_rotation : -30;
+			this.wm_tile_spacing = this.watermark_settings.tile_spacing || 40;
 			this.load_watermark_image(this.watermark_settings.watermark_image);
 		}
 
@@ -313,37 +398,50 @@ export default {
 				const ctx = canvas.getContext("2d");
 				const cw = canvas.width;
 				const ch = canvas.height;
-
-				// Watermark position is relative to the full image.
-				// Convert to cropped canvas coordinates.
 				const full_w = image_data.naturalWidth;
 				const full_h = image_data.naturalHeight;
-
-				// Watermark center in full image pixel space
-				const wm_center_x = (this.wm_pos_x / 100) * full_w;
-				const wm_center_y = (this.wm_pos_y / 100) * full_h;
-				const wm_w_full = (this.wm_size / 100) * full_w;
-				const wm_h_full = wm_w_full * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
-
-				// Crop box in full image pixel space
 				const crop_x = crop_data.x;
 				const crop_y = crop_data.y;
 				const crop_w = crop_data.width;
 				const crop_h = crop_data.height;
-
-				// Scale from crop pixel space to output canvas
 				const scale_x = cw / crop_w;
 				const scale_y = ch / crop_h;
 
-				// Watermark position in cropped canvas
-				const draw_x = (wm_center_x - wm_w_full / 2 - crop_x) * scale_x;
-				const draw_y = (wm_center_y - wm_h_full / 2 - crop_y) * scale_y;
-				const draw_w = wm_w_full * scale_x;
-				const draw_h = wm_h_full * scale_y;
+				if (this.wm_mode === "Tiled") {
+					// Tiled watermark on cropped canvas
+					const tile_w = (this.wm_tile_size / 100) * full_w * scale_x;
+					const tile_h = tile_w * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
+					const spacing_x = (this.wm_tile_spacing / 100) * full_w * scale_x;
+					const spacing_y = (this.wm_tile_spacing / 100) * full_h * scale_y;
+					const step_x = tile_w + spacing_x;
+					const step_y = tile_h + spacing_y;
+					const angle = (this.wm_tile_rotation * Math.PI) / 180;
 
-				ctx.globalAlpha = this.wm_opacity / 100;
-				ctx.drawImage(this.wm_img, draw_x, draw_y, draw_w, draw_h);
-				ctx.globalAlpha = 1.0;
+					ctx.save();
+					ctx.globalAlpha = this.wm_tile_opacity / 100;
+					ctx.translate(cw / 2, ch / 2);
+					ctx.rotate(angle);
+					const diag = Math.sqrt(cw * cw + ch * ch);
+					for (let y = -diag; y < diag; y += step_y) {
+						for (let x = -diag; x < diag; x += step_x) {
+							ctx.drawImage(this.wm_img, x, y, tile_w, tile_h);
+						}
+					}
+					ctx.restore();
+				} else {
+					// Corner watermark
+					const wm_center_x = (this.wm_pos_x / 100) * full_w;
+					const wm_center_y = (this.wm_pos_y / 100) * full_h;
+					const wm_w_full = (this.wm_size / 100) * full_w;
+					const wm_h_full = wm_w_full * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
+					const draw_x = (wm_center_x - wm_w_full / 2 - crop_x) * scale_x;
+					const draw_y = (wm_center_y - wm_h_full / 2 - crop_y) * scale_y;
+					const draw_w = wm_w_full * scale_x;
+					const draw_h = wm_h_full * scale_y;
+					ctx.globalAlpha = this.wm_opacity / 100;
+					ctx.drawImage(this.wm_img, draw_x, draw_y, draw_w, draw_h);
+					ctx.globalAlpha = 1.0;
+				}
 			}
 
 			const file_type = (this.bg_removed || this.wm_enabled) ? "image/png" : this.file.file_obj.type;
@@ -465,10 +563,16 @@ export default {
 			const ch = canvas.height;
 			ctx.clearRect(0, 0, cw, ch);
 
-			// Get the image display area within the cropper container
 			const cd = this.cropper.getCanvasData();
-			const r = this.wm_get_rect_in_container(cd);
 
+			if (this.wm_mode === "Tiled") {
+				this.wm_draw_tiled(ctx, cd);
+			} else {
+				this.wm_draw_corner(ctx, cd);
+			}
+		},
+		wm_draw_corner(ctx, cd) {
+			const r = this.wm_get_rect_in_container(cd);
 			ctx.globalAlpha = this.wm_opacity / 100;
 			ctx.drawImage(this.wm_img, r.x, r.y, r.w, r.h);
 			ctx.globalAlpha = 1.0;
@@ -478,6 +582,31 @@ export default {
 			ctx.setLineDash([4, 4]);
 			ctx.strokeRect(r.x, r.y, r.w, r.h);
 			ctx.setLineDash([]);
+		},
+		wm_draw_tiled(ctx, cd) {
+			const tile_w = (this.wm_tile_size / 100) * cd.width;
+			const tile_h = tile_w * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
+			const spacing_x = (this.wm_tile_spacing / 100) * cd.width;
+			const spacing_y = (this.wm_tile_spacing / 100) * cd.height;
+			const step_x = tile_w + spacing_x;
+			const step_y = tile_h + spacing_y;
+			const angle = (this.wm_tile_rotation * Math.PI) / 180;
+
+			ctx.save();
+			ctx.globalAlpha = this.wm_tile_opacity / 100;
+			// Rotate around image center
+			const cx = cd.left + cd.width / 2;
+			const cy = cd.top + cd.height / 2;
+			ctx.translate(cx, cy);
+			ctx.rotate(angle);
+
+			const diag = Math.sqrt(cd.width * cd.width + cd.height * cd.height);
+			for (let y = -diag; y < diag; y += step_y) {
+				for (let x = -diag; x < diag; x += step_x) {
+					ctx.drawImage(this.wm_img, x, y, tile_w, tile_h);
+				}
+			}
+			ctx.restore();
 		},
 		// Watermark rect in container/canvas display coordinates
 		wm_get_rect_in_container(cd) {
@@ -600,6 +729,30 @@ export default {
 			this.wm_opacity = Math.max(5, Math.min(100, val));
 			this.wm_draw();
 		},
+		wm_set_mode(mode) {
+			this.wm_mode = mode;
+			this.wm_draw();
+		},
+		wm_set_tile_size(val) {
+			if (isNaN(val)) return;
+			this.wm_tile_size = Math.max(5, Math.min(50, val));
+			this.wm_draw();
+		},
+		wm_set_tile_opacity(val) {
+			if (isNaN(val)) return;
+			this.wm_tile_opacity = Math.max(5, Math.min(100, val));
+			this.wm_draw();
+		},
+		wm_set_tile_rotation(val) {
+			if (isNaN(val)) return;
+			this.wm_tile_rotation = Math.max(-60, Math.min(0, val));
+			this.wm_draw();
+		},
+		wm_set_tile_spacing(val) {
+			if (isNaN(val)) return;
+			this.wm_tile_spacing = Math.max(10, Math.min(80, val));
+			this.wm_draw();
+		},
 		async wm_save_defaults() {
 			try {
 				await frappe.call({
@@ -608,18 +761,30 @@ export default {
 						doctype: "Watermark Settings",
 						name: "Watermark Settings",
 						fieldname: {
+							mode: this.wm_mode,
 							position_x: Math.round(this.wm_pos_x * 10) / 10,
 							position_y: Math.round(this.wm_pos_y * 10) / 10,
 							size: Math.round(this.wm_size * 10) / 10,
 							opacity: this.wm_opacity,
+							tile_size: Math.round(this.wm_tile_size * 10) / 10,
+							tile_opacity: this.wm_tile_opacity,
+							tile_rotation: this.wm_tile_rotation,
+							tile_spacing: this.wm_tile_spacing,
 						},
 					},
 				});
 				if (frappe._watermark_settings_cache) {
-					frappe._watermark_settings_cache.position_x = this.wm_pos_x;
-					frappe._watermark_settings_cache.position_y = this.wm_pos_y;
-					frappe._watermark_settings_cache.size = this.wm_size;
-					frappe._watermark_settings_cache.opacity = this.wm_opacity;
+					Object.assign(frappe._watermark_settings_cache, {
+						mode: this.wm_mode,
+						position_x: this.wm_pos_x,
+						position_y: this.wm_pos_y,
+						size: this.wm_size,
+						opacity: this.wm_opacity,
+						tile_size: this.wm_tile_size,
+						tile_opacity: this.wm_tile_opacity,
+						tile_rotation: this.wm_tile_rotation,
+						tile_spacing: this.wm_tile_spacing,
+					});
 				}
 				frappe.show_alert({ message: __("Watermark defaults saved"), indicator: "green" });
 			} catch (e) {
@@ -628,10 +793,16 @@ export default {
 		},
 		wm_reset_defaults() {
 			if (this.watermark_settings) {
-				this.wm_pos_x = this.watermark_settings.position_x || 80;
-				this.wm_pos_y = this.watermark_settings.position_y || 90;
-				this.wm_size = this.watermark_settings.size || 20;
-				this.wm_opacity = this.watermark_settings.opacity || 50;
+				const s = this.watermark_settings;
+				this.wm_mode = s.mode || "Corner";
+				this.wm_pos_x = s.position_x || 80;
+				this.wm_pos_y = s.position_y || 90;
+				this.wm_size = s.size || 20;
+				this.wm_opacity = s.opacity || 50;
+				this.wm_tile_size = s.tile_size || 15;
+				this.wm_tile_opacity = s.tile_opacity || 20;
+				this.wm_tile_rotation = s.tile_rotation != null ? s.tile_rotation : -30;
+				this.wm_tile_spacing = s.tile_spacing || 40;
 				this.wm_draw();
 				frappe.show_alert({ message: __("Reset to defaults"), indicator: "blue" });
 			}
@@ -819,6 +990,37 @@ img {
 .wm-panel-leave {
 	max-height: 220px;
 	opacity: 1;
+}
+
+.wm-mode-selector {
+	display: flex;
+	margin-bottom: 8px;
+	background: var(--bg-color);
+	border-radius: 6px;
+	padding: 2px;
+	width: fit-content;
+	border: 1px solid var(--border-color);
+}
+
+.wm-mode-btn {
+	padding: 3px 14px;
+	border: none;
+	border-radius: 4px;
+	font-size: var(--text-sm);
+	color: var(--text-muted);
+	background: transparent;
+	cursor: pointer;
+	transition: all 0.15s ease;
+}
+
+.wm-mode-btn:hover {
+	color: var(--text-color);
+}
+
+.wm-mode-btn.active {
+	background: white;
+	color: var(--primary);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 .wm-controls-panel {

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -57,6 +57,20 @@
 
 				<!-- Corner mode controls -->
 				<template v-if="wm_mode === 'Corner'">
+					<div class="wm-sliders-row">
+						<div class="wm-slider-field">
+							<label class="wm-control-label">{{ __("Opacity") }}</label>
+							<input type="range" class="wm-slider" min="5" max="100"
+								:value="wm_opacity" @input="wm_set_opacity(parseInt($event.target.value))" />
+							<span class="wm-slider-value">{{ wm_opacity }}%</span>
+						</div>
+						<div class="wm-slider-field">
+							<label class="wm-control-label">{{ __("Size") }}</label>
+							<input type="range" class="wm-slider" min="5" max="100"
+								:value="wm_size" @input="wm_set_size(parseFloat($event.target.value))" />
+							<span class="wm-slider-value">{{ Math.round(wm_size) }}%</span>
+						</div>
+					</div>
 					<div class="wm-controls-grid">
 						<div class="wm-control-field">
 							<label class="wm-control-label">{{ __("Position X") }}</label>
@@ -64,8 +78,7 @@
 								<input type="number" class="wm-input"
 									:value="Math.round(wm_pos_x * 10) / 10"
 									min="0" max="100" step="0.5"
-									@input="wm_set_pos_x(parseFloat($event.target.value))"
-								/>
+									@input="wm_set_pos_x(parseFloat($event.target.value))" />
 								<span class="wm-input-suffix">%</span>
 							</div>
 						</div>
@@ -75,8 +88,7 @@
 								<input type="number" class="wm-input"
 									:value="Math.round(wm_pos_y * 10) / 10"
 									min="0" max="100" step="0.5"
-									@input="wm_set_pos_y(parseFloat($event.target.value))"
-								/>
+									@input="wm_set_pos_y(parseFloat($event.target.value))" />
 								<span class="wm-input-suffix">%</span>
 							</div>
 						</div>
@@ -86,8 +98,7 @@
 								<input type="number" class="wm-input"
 									:value="Math.round(wm_size * 10) / 10"
 									min="5" max="100" step="1"
-									@input="wm_set_size(parseFloat($event.target.value))"
-								/>
+									@input="wm_set_size(parseFloat($event.target.value))" />
 								<span class="wm-input-suffix">%</span>
 							</div>
 						</div>
@@ -97,24 +108,41 @@
 								<input type="number" class="wm-input"
 									:value="wm_opacity"
 									min="5" max="100" step="1"
-									@input="wm_set_opacity(parseInt($event.target.value))"
-								/>
+									@input="wm_set_opacity(parseInt($event.target.value))" />
 								<span class="wm-input-suffix">%</span>
 							</div>
 						</div>
-					</div>
-					<div class="wm-opacity-row">
-						<label class="wm-control-label">{{ __("Opacity") }}</label>
-						<input type="range" class="wm-slider" min="5" max="100"
-							:value="wm_opacity"
-							@input="wm_set_opacity(parseInt($event.target.value))"
-						/>
-						<span class="wm-slider-value">{{ wm_opacity }}%</span>
 					</div>
 				</template>
 
 				<!-- Tiled mode controls -->
 				<template v-if="wm_mode === 'Tiled'">
+					<div class="wm-sliders-row">
+						<div class="wm-slider-field">
+							<label class="wm-control-label">{{ __("Opacity") }}</label>
+							<input type="range" class="wm-slider" min="5" max="100"
+								:value="wm_tile_opacity" @input="wm_set_tile_opacity(parseInt($event.target.value))" />
+							<span class="wm-slider-value">{{ wm_tile_opacity }}%</span>
+						</div>
+						<div class="wm-slider-field">
+							<label class="wm-control-label">{{ __("Tile Size") }}</label>
+							<input type="range" class="wm-slider" min="3" max="80"
+								:value="wm_tile_size" @input="wm_set_tile_size(parseInt($event.target.value))" />
+							<span class="wm-slider-value">{{ Math.round(wm_tile_size) }}%</span>
+						</div>
+						<div class="wm-slider-field">
+							<label class="wm-control-label">{{ __("Rotation") }}</label>
+							<input type="range" class="wm-slider" min="-180" max="180"
+								:value="wm_tile_rotation" @input="wm_set_tile_rotation(parseInt($event.target.value))" />
+							<span class="wm-slider-value">{{ wm_tile_rotation }}°</span>
+						</div>
+						<div class="wm-slider-field">
+							<label class="wm-control-label">{{ __("Spacing") }}</label>
+							<input type="range" class="wm-slider" min="0" max="100"
+								:value="wm_tile_spacing" @input="wm_set_tile_spacing(parseInt($event.target.value))" />
+							<span class="wm-slider-value">{{ wm_tile_spacing }}%</span>
+						</div>
+					</div>
 					<div class="wm-controls-grid">
 						<div class="wm-control-field">
 							<label class="wm-control-label">{{ __("Tile Size") }}</label>
@@ -122,8 +150,7 @@
 								<input type="number" class="wm-input"
 									:value="Math.round(wm_tile_size)"
 									min="3" max="80" step="1"
-									@input="wm_set_tile_size(parseInt($event.target.value))"
-								/>
+									@input="wm_set_tile_size(parseInt($event.target.value))" />
 								<span class="wm-input-suffix">%</span>
 							</div>
 						</div>
@@ -133,8 +160,7 @@
 								<input type="number" class="wm-input"
 									:value="wm_tile_opacity"
 									min="5" max="100" step="1"
-									@input="wm_set_tile_opacity(parseInt($event.target.value))"
-								/>
+									@input="wm_set_tile_opacity(parseInt($event.target.value))" />
 								<span class="wm-input-suffix">%</span>
 							</div>
 						</div>
@@ -143,9 +169,8 @@
 							<div class="wm-input-group">
 								<input type="number" class="wm-input"
 									:value="wm_tile_rotation"
-									min="-60" max="60" step="1"
-									@input="wm_set_tile_rotation(parseInt($event.target.value))"
-								/>
+									min="-180" max="180" step="1"
+									@input="wm_set_tile_rotation(parseInt($event.target.value))" />
 								<span class="wm-input-suffix">°</span>
 							</div>
 						</div>
@@ -155,19 +180,10 @@
 								<input type="number" class="wm-input"
 									:value="wm_tile_spacing"
 									min="0" max="100" step="1"
-									@input="wm_set_tile_spacing(parseInt($event.target.value))"
-								/>
+									@input="wm_set_tile_spacing(parseInt($event.target.value))" />
 								<span class="wm-input-suffix">%</span>
 							</div>
 						</div>
-					</div>
-					<div class="wm-opacity-row">
-						<label class="wm-control-label">{{ __("Opacity") }}</label>
-						<input type="range" class="wm-slider" min="5" max="100"
-							:value="wm_tile_opacity"
-							@input="wm_set_tile_opacity(parseInt($event.target.value))"
-						/>
-						<span class="wm-slider-value">{{ wm_tile_opacity }}%</span>
 					</div>
 				</template>
 
@@ -277,7 +293,7 @@ export default {
 			wm_mode: "Corner",
 			// Tiled mode params
 			wm_tile_size: 15,
-			wm_tile_opacity: 20,
+			wm_tile_opacity: 12,
 			wm_tile_rotation: -30,
 			wm_tile_spacing: 40,
 			// Interaction mode
@@ -745,7 +761,7 @@ export default {
 		},
 		wm_set_tile_rotation(val) {
 			if (isNaN(val)) return;
-			this.wm_tile_rotation = Math.max(-60, Math.min(60, val));
+			this.wm_tile_rotation = Math.max(-180, Math.min(180, val));
 			this.wm_draw();
 		},
 		wm_set_tile_spacing(val) {
@@ -1092,20 +1108,23 @@ img {
 	flex-shrink: 0;
 }
 
-.wm-opacity-row {
+.wm-sliders-row {
 	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-top: 8px;
+	gap: 12px;
+	flex-wrap: wrap;
+	margin-bottom: 8px;
 }
 
-.wm-opacity-row .wm-control-label {
-	flex-shrink: 0;
-	min-width: 46px;
+.wm-slider-field {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 100px;
 }
 
 .wm-slider {
-	flex: 1;
+	width: 100%;
 	height: 4px;
 	cursor: pointer;
 	accent-color: var(--primary);
@@ -1114,9 +1133,7 @@ img {
 .wm-slider-value {
 	font-size: 11px;
 	color: var(--text-muted);
-	min-width: 36px;
-	text-align: right;
-	flex-shrink: 0;
+	text-align: center;
 }
 
 .wm-panel-actions {

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -121,7 +121,7 @@
 							<div class="wm-input-group">
 								<input type="number" class="wm-input"
 									:value="Math.round(wm_tile_size)"
-									min="5" max="50" step="1"
+									min="3" max="80" step="1"
 									@input="wm_set_tile_size(parseInt($event.target.value))"
 								/>
 								<span class="wm-input-suffix">%</span>
@@ -143,7 +143,7 @@
 							<div class="wm-input-group">
 								<input type="number" class="wm-input"
 									:value="wm_tile_rotation"
-									min="-60" max="0" step="1"
+									min="-60" max="60" step="1"
 									@input="wm_set_tile_rotation(parseInt($event.target.value))"
 								/>
 								<span class="wm-input-suffix">°</span>
@@ -154,7 +154,7 @@
 							<div class="wm-input-group">
 								<input type="number" class="wm-input"
 									:value="wm_tile_spacing"
-									min="10" max="80" step="1"
+									min="0" max="100" step="1"
 									@input="wm_set_tile_spacing(parseInt($event.target.value))"
 								/>
 								<span class="wm-input-suffix">%</span>
@@ -735,7 +735,7 @@ export default {
 		},
 		wm_set_tile_size(val) {
 			if (isNaN(val)) return;
-			this.wm_tile_size = Math.max(5, Math.min(50, val));
+			this.wm_tile_size = Math.max(3, Math.min(80, val));
 			this.wm_draw();
 		},
 		wm_set_tile_opacity(val) {
@@ -745,12 +745,12 @@ export default {
 		},
 		wm_set_tile_rotation(val) {
 			if (isNaN(val)) return;
-			this.wm_tile_rotation = Math.max(-60, Math.min(0, val));
+			this.wm_tile_rotation = Math.max(-60, Math.min(60, val));
 			this.wm_draw();
 		},
 		wm_set_tile_spacing(val) {
 			if (isNaN(val)) return;
-			this.wm_tile_spacing = Math.max(10, Math.min(80, val));
+			this.wm_tile_spacing = Math.max(0, Math.min(100, val));
 			this.wm_draw();
 		},
 		async wm_save_defaults() {

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -21,11 +21,15 @@ export default class FileUploader {
 		make_attachments_public,
 		show_remove_bg,
 		remove_bg_default,
+		remove_bg_disabled_hint,
+		remove_bg_disabled_link,
 		show_watermark,
 		watermark_settings,
 	} = {}) {
 		frm && frm.attachments.max_reached(true);
 		this.show_remove_bg = show_remove_bg;
+		this.remove_bg_disabled_hint = remove_bg_disabled_hint;
+		this.remove_bg_disabled_link = remove_bg_disabled_link;
 		this.show_watermark = show_watermark;
 		this.watermark_settings = watermark_settings;
 
@@ -56,6 +60,7 @@ export default class FileUploader {
 						make_attachments_public,
 						show_remove_bg,
 						remove_bg_default,
+						remove_bg_disabled_hint,
 						show_watermark,
 						watermark_settings,
 					},
@@ -113,7 +118,9 @@ export default class FileUploader {
 				"remove_bg",
 				__("Remove Background"),
 				"remove_bg_checked",
-				true,
+				!this.remove_bg_disabled_hint,
+				this.remove_bg_disabled_hint || null,
+				this.remove_bg_disabled_link || null,
 			);
 		}
 		if (this.dialog && this.show_watermark) {

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -108,6 +108,16 @@ export default class FileUploader {
 			}
 		});
 
+		// Disable Upload/Set all private only while an upload is actually
+		// in-flight (currently_uploading >= 0). Re-enable when idle (-1) so
+		// users can retry after a failed upload or after cancelling a crop.
+		this.uploader.$watch("currently_uploading", (val) => {
+			if (!this.dialog) return;
+			const uploading = val >= 0;
+			this.dialog.get_primary_btn().prop("disabled", uploading);
+			this.dialog.get_secondary_btn().prop("disabled", uploading);
+		});
+
 		if (files && files.length) {
 			this.uploader.add_files(files);
 		}
@@ -137,8 +147,25 @@ export default class FileUploader {
 	}
 
 	upload_files() {
-		this.dialog && this.dialog.get_primary_btn().prop("disabled", true);
-		this.dialog && this.dialog.get_secondary_btn().prop("disabled", true);
+		// Guard against clicking Upload before a file is selected. Without this,
+		// the no-op upload would still trigger the disable path below and leave
+		// users stuck. Special modes (file_browser, web_link) handle their own
+		// no-selection case downstream.
+		const uploader = this.uploader;
+		const has_files = uploader && uploader.files && uploader.files.length > 0;
+		const in_special_mode =
+			uploader && (uploader.show_file_browser || uploader.show_web_link);
+		if (!has_files && !in_special_mode) {
+			frappe.show_alert({
+				message: __("Please select a file first"),
+				indicator: "orange",
+			});
+			return;
+		}
+
+		// Button state is managed by the currently_uploading watcher below —
+		// only really disable while an upload is in-flight, so users can still
+		// re-click Upload after cropping or after a failed attempt.
 		return this.uploader.upload_files();
 	}
 


### PR DESCRIPTION
## Summary

Follow-up PR to pps190/frappe#29 (already merged). Adds two independent improvements to the FileUploader on the `feature/upload-remove-bg` branch, required by the matching refactor in **pps190/next#493**.

## 1. Disabled-with-hint support for Remove BG toggle

Match the existing behaviour of the Watermark toggle: when Remove BG is not available (service not configured, or feature disabled in settings), render the footer pill in a disabled state with a hint instead of hiding it. Clicking a disabled pill optionally opens a settings page.

**Why**: The `next` app now runs Remove BG exclusively through a remote microservice (see pps190/next#493). When that service is not yet configured in `site_config.json`, the user needs a clear explanation instead of a cryptic 500 error or a silently missing button.

**Changes**:
- `index.js` — FileUploader constructor accepts `remove_bg_disabled_hint` and `remove_bg_disabled_link` props; passes them to `add_footer_toggle()` which already supported disabled+hint rendering for Watermark.
- `FileUploader.vue` — add `remove_bg_disabled_hint` prop; initialize `remove_bg_checked=false` when disabled; pass `show_remove_bg && !remove_bg_disabled_hint` to ImageCropper so the inline pill inside the cropper also disappears when unavailable.

## 2. Upload button state fix

The primary Upload button was being disabled the moment `upload_files()` was called, then never re-enabled except by the dialog closing. This left the button stuck in two real scenarios:

1. **Click Upload before selecting a file** — `upload_files()` runs a no-op `frappe.run_serially([])`, button stays disabled forever.
2. **Click Upload → enter image cropper → click Crop to return to preview** — button is still disabled from step 1, so the final Upload confirmation can't be clicked.

The original intent of disabling the button was to prevent double-submit during an in-flight upload. That goal is legitimate, but the implementation was triggered on user intent rather than actual upload state.

**Changes**:
- Remove the unconditional disable from `upload_files()`.
- Add a guard with a non-blocking `frappe.show_alert` when Upload is clicked with no files selected (instead of silently doing nothing).
- Watch `currently_uploading` on the Vue uploader — disable both primary/secondary buttons only while it is `>= 0` (actively uploading), re-enable when it returns to `-1` (idle, failed, or cancelled).
- Reset `currently_uploading` to `-1` in a `.finally()` on the upload pipeline so a failed upload lets the user retry.

### Upload button state table

| Scenario | Button state |
|---|---|
| Dialog open, no file | enable |
| Click Upload with no file | enable + orange "Please select a file first" alert |
| Selected a file, preview | enable |
| Click Upload → enter cropper | enable (no actual upload yet) |
| Crop → return to preview | enable |
| **Upload in flight** | **disable** ← real double-submit protection |
| Upload succeeds | dialog auto-closes |
| Upload fails | **re-enable**, user can retry |

## Related

- **pps190/next#493** — refactor to call remote microservice; passes `remove_bg_disabled_hint` from this PR
- **pps190/remove-bg-service** — standalone FastAPI + rembg microservice (new repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)