### PR TITLE
feat(file-uploader): crop toolbar with aspect + solid background + comment boxes

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -3,6 +3,7 @@
 		class="file-uploader"
 		:class="{
 			'fu-with-panel': any_feature_shown && !show_image_cropper && !show_file_browser && !show_web_link,
+			'fu-cropper-mode': show_image_cropper,
 		}"
 		@dragover.prevent="dragover"
 		@dragleave.prevent="dragleave"
@@ -2166,9 +2167,20 @@ export default {
 	flex-direction: column;
 }
 /* When the ImageCropper mounts, its .cropper-grid should fill the body so
-   the left column can distribute height (toolbar / image / preview). */
-.file-uploader-dialog .modal-body > .file-uploader { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
-.file-uploader-dialog .modal-body > .file-uploader > .cropper-grid { flex: 1 1 auto; min-height: 0; }
+   the left column can distribute height (toolbar / image / preview).
+   Scoped to .fu-cropper-mode so it doesn't override the Step 1/3 grid
+   layout (.fu-with-panel uses display: grid, and a blanket flex-column
+   rule on .file-uploader would beat that specificity). */
+.file-uploader-dialog .modal-body > .file-uploader.fu-cropper-mode {
+	flex: 1 1 auto;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+.file-uploader-dialog .modal-body > .file-uploader.fu-cropper-mode > .cropper-grid {
+	flex: 1 1 auto;
+	min-height: 0;
+}
 /* Footer region — standard-actions holds the primary Upload button,
    custom-actions holds the feature toggles (Watermark / Remove BG
    pills). Space them properly so they don't collide, and wrap on

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -474,6 +474,7 @@
 							:presets="comment_presets || []"
 							:defaults="local_comment_defaults || {}"
 							:enabled="comments_enabled_default"
+							@input="step1_comment_boxes = $event"
 							@change="step1_comment_boxes = $event"
 							@reset-enabled="comments_enabled_default = !!(comment_defaults && comment_defaults.enabled)"
 						/>

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -263,13 +263,6 @@
 									: __("off") }}
 							</span>
 						</li>
-						<li v-if="show_resize" :class="{ off: !recap.resize_enabled }">
-							<span class="fu-recap-dot" :class="recap.resize_enabled ? 'on' : 'off'"></span>
-							<span class="fu-recap-label">{{ __("Canvas") }}</span>
-							<span class="fu-recap-value">
-								{{ recap.resize_enabled ? recap.resize_aspect : __("off") }}
-							</span>
-						</li>
 					</ul>
 				</div>
 			</template>
@@ -480,57 +473,6 @@
 						/>
 					</div>
 
-					<!-- ── CANVAS pane ── -->
-					<div v-show="active_tab === 'canvas'" class="cropper-tab-pane">
-						<div class="cropper-tab-enable">
-							<span class="cropper-tab-enable-label">{{ __("Enable Canvas normalization") }}</span>
-							<div
-								class="toggle-pill toggle-pill-compact"
-								:class="{ active: resize_enabled_default }"
-								@click="resize_enabled_default = !resize_enabled_default"
-							>
-								<span class="toggle-pill-switch">
-									<span class="toggle-pill-track" :class="{ on: resize_enabled_default }">
-										<span class="toggle-pill-thumb"></span>
-									</span>
-								</span>
-							</div>
-						</div>
-						<div v-if="resize_enabled_default && local_resize_settings" class="adjustments-row">
-							<label class="adjustments-field-label">{{ __("Aspect") }}</label>
-							<div class="segmented-tabs segmented-tabs-aspect" role="tablist">
-								<button v-for="opt in ['1:1', '4:3', '16:9', '3:2', '2:3', 'Free']" :key="opt"
-									type="button" class="segmented-tab"
-									:class="{ active: (local_resize_settings.resize_aspect || '1:1') === opt }"
-									@click="_set_canvas_aspect(opt)">{{ opt }}</button>
-							</div>
-							<label class="adjustments-field-label" style="margin-top:12px">{{ __("Mode") }}</label>
-							<div class="segmented-tabs" role="tablist">
-								<button v-for="opt in ['Contain', 'Cover', 'Stretch']" :key="opt"
-									type="button" class="segmented-tab"
-									:class="{ active: (local_resize_settings.resize_mode || 'Contain') === opt }"
-									@click="_set_canvas_mode(opt)">{{ __(opt) }}</button>
-							</div>
-							<div class="wm-inline-row">
-								<label class="wm-inline-check">
-									<input type="checkbox"
-										:checked="local_resize_settings.resize_flatten_rgb !== false"
-										@change="_set_canvas_field('resize_flatten_rgb', $event.target.checked ? 1 : 0)" />
-									<span>{{ __("Solid Background") }}</span>
-								</label>
-								<label v-if="local_resize_settings.resize_flatten_rgb !== false" class="wm-inline-colour">
-									<span>{{ __("Color") }}</span>
-									<input type="color"
-										:value="local_resize_settings.resize_fill_color || '#FFFFFF'"
-										@input="_set_canvas_field('resize_fill_color', $event.target.value)" />
-								</label>
-							</div>
-							<div class="wm-panel-actions">
-								<button class="btn btn-xs btn-default" @click="_reset_canvas_default">{{ __("Reset") }}</button>
-								<button class="btn btn-xs btn-primary-light" @click="_save_canvas_default">{{ __("Save as Default") }}</button>
-							</div>
-						</div>
-					</div>
 				</div>
 			</template>
 		</div><!-- /.fu-right-col -->
@@ -542,12 +484,12 @@
 			:show_remove_bg="show_remove_bg && !remove_bg_disabled_hint"
 			:remove_bg_checked="remove_bg_checked"
 			:remove_bg_padding_pct="step1_padding_pct"
+			:default_crop_aspect="default_crop_aspect"
+			:default_solid_background="default_solid_background"
+			:default_background_color="default_background_color"
 			:show_watermark="show_watermark"
 			:watermark_settings="local_watermark_settings"
 			:wm_default_enabled="wm_enabled"
-			:show_resize="show_resize"
-			:resize_settings="local_resize_settings"
-			:resize_default_enabled="resize_enabled_default"
 			:show_comments="show_comments"
 			:comment_defaults="local_comment_defaults"
 			:comment_presets="comment_presets"
@@ -558,7 +500,6 @@
 			@remove_bg_changed="remove_bg_checked = $event"
 			@wm_enabled_changed="wm_enabled = $event"
 			@comments_enabled_changed="comments_enabled_default = $event"
-			@resize_enabled_changed="resize_enabled_default = $event"
 			@crop_committed="_on_crop_committed"
 		/>
 		<FileBrowser
@@ -645,18 +586,26 @@ export default {
 		remove_bg_padding_pct: {
 			default: 5,
 		},
+		// Initial crop-box aspect remembered per user in Image Processing
+		// Settings. String form from the settings doc: "Free" | "1:1"
+		// | "4:3" | "16:9". ImageCropper maps to a numeric ratio and
+		// preselects the matching button in its toolbar.
+		default_crop_aspect: {
+			default: "Free",
+		},
+		// Initial Solid Background + colour remembered in Settings. The
+		// cropper exposes a toolbar toggle + colour picker; the active
+		// value is shown live behind the image so users see the output.
+		default_solid_background: {
+			default: false,
+		},
+		default_background_color: {
+			default: "#FFFFFF",
+		},
 		show_watermark: {
 			default: false,
 		},
 		watermark_settings: {
-			default: null,
-		},
-		// Resize (new 2026-04) — aspect normalization applied at
-		// Crop time. Mirror of Image Processing Settings' resize_* fields.
-		show_resize: {
-			default: false,
-		},
-		resize_settings: {
 			default: null,
 		},
 		// Comments (new 2026-04) — show the text-overlay list editor in
@@ -700,10 +649,9 @@ export default {
 			wrapper_ready: false,
 			remove_bg_checked: this.remove_bg_default && !this.remove_bg_disabled_hint,
 			wm_enabled: this.watermark_settings && this.watermark_settings.enabled ? true : false,
-			// Pre-cropper toggles for Comments + Canvas so the file-picker
-			// page exposes the same 4 features the cropper tab-panel does.
+			// Pre-cropper toggle for Comments so the file-picker page
+			// exposes the same feature the cropper tab-panel does.
 			comments_enabled_default: !!(this.comment_defaults && this.comment_defaults.enabled),
-			resize_enabled_default: !!(this.resize_settings && this.resize_settings.resize_enabled),
 			// Step-1 comment box list, seeded from Settings.comment_presets
 			// so "Save as Default" and the initial hydrated list stay in
 			// sync. Any edits here carry over into the cropper's Step 2
@@ -735,9 +683,6 @@ export default {
 			// Step 2 edits roundtrip cleanly.
 			local_watermark_settings: this.watermark_settings
 				? JSON.parse(JSON.stringify(this.watermark_settings))
-				: null,
-			local_resize_settings: this.resize_settings
-				? JSON.parse(JSON.stringify(this.resize_settings))
 				: null,
 			local_comment_defaults: this.comment_defaults
 				? JSON.parse(JSON.stringify(this.comment_defaults))
@@ -795,8 +740,7 @@ export default {
 		// — a plain Attachment upload (no image processing) stays
 		// single-column like the original Frappe uploader.
 		any_feature_shown() {
-			return !!(this.show_remove_bg || this.show_watermark
-				|| this.show_comments || this.show_resize);
+			return !!(this.show_remove_bg || this.show_watermark || this.show_comments);
 		},
 		// Step 3 recap view: prefer post-crop snapshot (last_crop_settings)
 		// so it reflects whatever the user committed in the cropper,
@@ -812,13 +756,7 @@ export default {
 					|| "Tiled",
 				comments_enabled: s.comments_enabled != null ? s.comments_enabled : this.comments_enabled_default,
 				comment_count: s.comment_count || 0,
-				resize_enabled: s.resize_enabled != null ? s.resize_enabled : this.resize_enabled_default,
-				resize_aspect: s.resize_aspect
-					|| (this.local_resize_settings && this.local_resize_settings.resize_aspect)
-					|| "1:1",
-				resize_mode: s.resize_mode
-					|| (this.local_resize_settings && this.local_resize_settings.resize_mode)
-					|| "Contain",
+				crop_aspect: s.crop_aspect || this.default_crop_aspect || "Free",
 			};
 		},
 		// Tab objects used by the v-for in the template. Each entry knows
@@ -845,13 +783,6 @@ export default {
 					key: "comments",
 					label: __("Comments"),
 					on: !!this.comments_enabled_default,
-				});
-			}
-			if (this.show_resize) {
-				tabs.push({
-					key: "canvas",
-					label: __("Canvas"),
-					on: !!this.resize_enabled_default,
 				});
 			}
 			return tabs;
@@ -882,17 +813,8 @@ export default {
 			this.remove_bg_checked = !!snapshot.remove_bg;
 			this.wm_enabled = !!snapshot.watermark_enabled;
 			this.comments_enabled_default = !!snapshot.comments_enabled;
-			this.resize_enabled_default = !!snapshot.resize_enabled;
 			if (this.local_watermark_settings && snapshot.watermark_mode) {
 				this.$set(this.local_watermark_settings, "mode", snapshot.watermark_mode);
-			}
-			if (this.local_resize_settings) {
-				if (snapshot.resize_aspect) {
-					this.$set(this.local_resize_settings, "resize_aspect", snapshot.resize_aspect);
-				}
-				if (snapshot.resize_mode) {
-					this.$set(this.local_resize_settings, "resize_mode", snapshot.resize_mode);
-				}
 			}
 		},
 		_set_wm_field(field, value) {
@@ -902,18 +824,6 @@ export default {
 		_set_comment_default(field, value) {
 			if (!this.local_comment_defaults) return;
 			this.$set(this.local_comment_defaults, field, value);
-		},
-		_set_canvas_aspect(opt) {
-			if (!this.local_resize_settings) return;
-			this.$set(this.local_resize_settings, "resize_aspect", opt);
-		},
-		_set_canvas_mode(opt) {
-			if (!this.local_resize_settings) return;
-			this.$set(this.local_resize_settings, "resize_mode", opt);
-		},
-		_set_canvas_field(field, value) {
-			if (!this.local_resize_settings) return;
-			this.$set(this.local_resize_settings, field, value);
 		},
 
 		// ── Reset / Save-as-default buttons per tab ─────────────────
@@ -1029,33 +939,6 @@ export default {
 			});
 		},
 
-		_reset_canvas_default() {
-			if (!this.resize_settings) return;
-			this.local_resize_settings = JSON.parse(JSON.stringify(this.resize_settings));
-			frappe.show_alert({ message: __("Reset to saved defaults"), indicator: "blue" });
-		},
-		_save_canvas_default() {
-			const r = this.local_resize_settings;
-			if (!r) return;
-			frappe.call({
-				method: "frappe.client.set_value",
-				args: {
-					doctype: "Image Processing Settings",
-					name: "Image Processing Settings",
-					fieldname: {
-						resize_enabled: this.resize_enabled_default ? 1 : 0,
-						resize_aspect: r.resize_aspect || "1:1",
-						resize_mode: r.resize_mode || "Contain",
-						resize_fill_color: r.resize_fill_color || "#FFFFFF",
-						resize_flatten_rgb: r.resize_flatten_rgb !== false ? 1 : 0,
-					},
-				},
-			}).then(() => {
-				frappe.show_alert({ message: __("Canvas defaults saved"), indicator: "green" });
-			}).catch(() => {
-				frappe.show_alert({ message: __("Failed to save defaults"), indicator: "red" });
-			});
-		},
 		dragover() {
 			this.is_dragging = true;
 		},
@@ -1151,11 +1034,17 @@ export default {
 			}
 
 			this.files = this.files.concat(files);
-			// if only one file is allowed and crop_image_aspect_ratio is set, open cropper immediately
+			// Single-file single-image flow: auto-open the cropper if we
+			// have any image-processing feature enabled (Remove BG / Watermark /
+			// Canvas / Comments) OR a fixed aspect restriction. Originally the
+			// gate was "aspect restriction set" — but once we removed the
+			// forced 1:1 on attach_doc_image, single-item uploads started
+			// skipping the cropper straight to Step 3. Re-use
+			// any_feature_shown so any opt-in feature triggers the cropper.
 			if (
 				this.files.length === 1 &&
 				!this.allow_multiple &&
-				this.restrictions.crop_image_aspect_ratio != null
+				(this.restrictions.crop_image_aspect_ratio != null || this.any_feature_shown)
 			) {
 				if (!this.files[0].file_obj.type.includes("svg")) {
 					this.toggle_image_cropper(0);

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -1058,9 +1058,9 @@ export default {
 .file-uploader { display: block; }
 .file-uploader.fu-with-panel {
 	display: grid;
-	grid-template-columns: minmax(0, 1fr) 320px;
-	gap: 16px;
-	align-items: start;
+	grid-template-columns: minmax(0, 1fr) 420px;
+	gap: 20px;
+	align-items: stretch;
 }
 .file-uploader .fu-left-col { min-width: 0; }
 .file-uploader .fu-right-col {
@@ -1069,35 +1069,35 @@ export default {
 	border: 1px solid var(--border-color);
 	border-radius: 10px;
 	background: #fff;
-	padding: 12px;
+	padding: 18px;
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: 16px;
+	min-height: 360px;
 }
 
 /* Tab header strip ─ matches the cropper's .cropper-feature-tabs
    visual style so Step 1 and Step 2 look like the same control. */
 .fu-feature-tabs {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
-	gap: 4px;
+	grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+	gap: 6px;
 	background: #f1f5f9;
-	border-radius: 8px;
-	padding: 4px;
+	border-radius: 10px;
+	padding: 6px;
 }
 .fu-feature-tab {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 3px;
-	padding: 8px 6px;
+	gap: 5px;
+	padding: 12px 8px;
 	background: transparent;
 	border: none;
-	border-radius: 6px;
+	border-radius: 8px;
 	cursor: pointer;
 	color: #64748b;
-	font-size: 12px;
 	transition: background 0.15s ease, color 0.15s ease;
 }
 .fu-feature-tab:hover { background: rgba(255, 255, 255, 0.55); }
@@ -1108,14 +1108,14 @@ export default {
 }
 .fu-feature-tab-label {
 	font-weight: 600;
-	font-size: 11px;
+	font-size: 15px;
 	line-height: 1.2;
 }
 .fu-feature-tab-state {
 	display: inline-flex;
 	align-items: center;
-	gap: 3px;
-	font-size: 10px;
+	gap: 4px;
+	font-size: 13px;
 	font-weight: 500;
 	text-transform: uppercase;
 	letter-spacing: 0.02em;
@@ -1123,8 +1123,8 @@ export default {
 .fu-feature-tab-state.on { color: #10b981; }
 .fu-feature-tab-state.off { color: #94a3b8; }
 .fu-feature-tab-dot {
-	width: 6px;
-	height: 6px;
+	width: 8px;
+	height: 8px;
 	border-radius: 50%;
 	background: currentColor;
 }
@@ -1133,29 +1133,29 @@ export default {
 .fu-tab-pane {
 	display: flex;
 	flex-direction: column;
-	gap: 10px;
+	gap: 14px;
 }
 .fu-tab-enable {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding: 8px 10px;
+	padding: 14px 16px;
 	border: 1px solid var(--border-color);
-	border-radius: 6px;
+	border-radius: 8px;
 	background: #fafbfc;
 }
 .fu-tab-enable-label {
-	font-size: 13px;
+	font-size: 16px;
 	font-weight: 600;
 	color: #303133;
 }
 .fu-tab-note {
-	font-size: 12px;
+	font-size: 14px;
 	color: var(--text-muted);
-	line-height: 1.5;
-	padding: 8px 10px;
+	line-height: 1.55;
+	padding: 12px 14px;
 	background: #f8fafc;
-	border-radius: 6px;
+	border-radius: 8px;
 }
 .fu-tab-note a {
 	color: var(--primary);
@@ -1165,10 +1165,10 @@ export default {
 .fu-tab-field {
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: 6px;
 }
 .fu-tab-field-label {
-	font-size: 11px;
+	font-size: 14px;
 	font-weight: 600;
 	color: #475569;
 	text-transform: uppercase;
@@ -1178,16 +1178,16 @@ export default {
 .fu-seg-row {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 4px;
+	gap: 6px;
 }
 .fu-seg-btn {
-	padding: 4px 10px;
-	font-size: 12px;
+	padding: 7px 14px;
+	font-size: 14px;
 	font-weight: 500;
 	color: #475569;
 	background: #fff;
 	border: 1px solid var(--border-color);
-	border-radius: 4px;
+	border-radius: 6px;
 	cursor: pointer;
 	transition: all 0.15s ease;
 }
@@ -1210,9 +1210,9 @@ export default {
 }
 .fu-toggle-track {
 	display: inline-block;
-	width: 30px;
-	height: 16px;
-	border-radius: 8px;
+	width: 40px;
+	height: 22px;
+	border-radius: 11px;
 	background: #cbd5e1;
 	position: relative;
 	transition: background 0.2s ease;
@@ -1220,31 +1220,32 @@ export default {
 .fu-toggle-track.on { background: var(--primary); }
 .fu-toggle-thumb {
 	position: absolute;
-	top: 2px;
-	left: 2px;
-	width: 12px;
-	height: 12px;
+	top: 3px;
+	left: 3px;
+	width: 16px;
+	height: 16px;
 	border-radius: 50%;
 	background: #fff;
 	transition: transform 0.2s ease;
 }
-.fu-toggle-track.on .fu-toggle-thumb { transform: translateX(14px); }
+.fu-toggle-track.on .fu-toggle-thumb { transform: translateX(18px); }
 
 /* ── Recap card (Step 3) ────────────────────────────────────────── */
 .fu-recap-card {
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: 6px;
 }
 .fu-recap-title {
-	font-size: 13px;
+	font-size: 16px;
 	font-weight: 600;
 	color: #0f172a;
 }
 .fu-recap-hint {
-	font-size: 11px;
+	font-size: 13px;
 	color: var(--text-muted);
-	margin-bottom: 8px;
+	margin-bottom: 10px;
+	line-height: 1.5;
 }
 .fu-recap-list {
 	list-style: none;
@@ -1252,49 +1253,59 @@ export default {
 	padding: 0;
 	display: flex;
 	flex-direction: column;
-	gap: 6px;
+	gap: 8px;
 }
 .fu-recap-list li {
 	display: grid;
-	grid-template-columns: 10px 1fr auto;
+	grid-template-columns: 12px 1fr auto;
 	align-items: center;
-	gap: 8px;
-	padding: 8px 10px;
+	gap: 12px;
+	padding: 12px 14px;
 	border: 1px solid var(--border-color);
-	border-radius: 6px;
+	border-radius: 8px;
 	background: #fafbfc;
-	font-size: 12px;
+	font-size: 15px;
 }
 .fu-recap-list li.off {
 	background: #f8fafc;
 	color: #94a3b8;
 }
 .fu-recap-dot {
-	width: 8px;
-	height: 8px;
+	width: 10px;
+	height: 10px;
 	border-radius: 50%;
 }
 .fu-recap-dot.on  { background: #10b981; }
 .fu-recap-dot.off { background: #cbd5e1; }
 .fu-recap-label { font-weight: 500; }
 .fu-recap-value {
-	font-size: 11px;
+	font-size: 13px;
 	color: #64748b;
 	text-transform: uppercase;
 	letter-spacing: 0.03em;
+	font-weight: 500;
 }
 
 /* ── Mobile: stack right column below left ─────────────────────── */
-@media (max-width: 768px) {
+@media (max-width: 900px) {
 	.file-uploader.fu-with-panel {
 		grid-template-columns: 1fr;
+		gap: 16px;
 	}
 	.file-uploader .fu-right-col {
 		position: static;
+		min-height: 0;
+		padding: 14px;
 	}
 	.fu-feature-tabs {
 		grid-template-columns: repeat(4, 1fr);
 	}
+	.fu-feature-tab { padding: 10px 4px; }
+	.fu-feature-tab-label { font-size: 14px; }
+	.fu-feature-tab-state { font-size: 12px; }
+	.fu-tab-enable-label { font-size: 15px; }
+	.fu-tab-note { font-size: 13px; }
+	.fu-recap-list li { font-size: 14px; padding: 10px 12px; }
 }
 
 .file-upload-area {

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -230,35 +230,44 @@
 			class="fu-right-col"
 			v-if="any_feature_shown && !show_image_cropper && !show_file_browser && !show_web_link"
 		>
-			<!-- Step 3 (files added, crop committed): read-only recap -->
+			<!-- Step 3 (files added, crop committed): read-only recap.
+			     Prefers last_crop_settings (populated by @crop_committed so
+			     the recap reflects the exact state baked into the file)
+			     and falls back to the Step 1 default toggles when the user
+			     hasn't cropped yet (e.g. they skipped the cropper on a
+			     non-image file). -->
 			<template v-if="files.length > 0">
 				<div class="fu-recap-card">
 					<div class="fu-recap-title">{{ __("Applied to your image") }}</div>
-					<div class="fu-recap-hint">{{ __("Locked in at the Crop step — cannot be edited after upload.") }}</div>
+					<div class="fu-recap-hint">{{ __("Locked in at the Crop step — reopen the cropper to change these.") }}</div>
 					<ul class="fu-recap-list">
-						<li v-if="show_remove_bg" :class="{ off: !remove_bg_checked }">
-							<span class="fu-recap-dot" :class="remove_bg_checked ? 'on' : 'off'"></span>
+						<li v-if="show_remove_bg" :class="{ off: !recap.remove_bg }">
+							<span class="fu-recap-dot" :class="recap.remove_bg ? 'on' : 'off'"></span>
 							<span class="fu-recap-label">{{ __("Remove Background") }}</span>
-							<span class="fu-recap-value">{{ remove_bg_checked ? __("on") : __("off") }}</span>
+							<span class="fu-recap-value">{{ recap.remove_bg ? __("on") : __("off") }}</span>
 						</li>
-						<li v-if="show_watermark" :class="{ off: !wm_enabled }">
-							<span class="fu-recap-dot" :class="wm_enabled ? 'on' : 'off'"></span>
+						<li v-if="show_watermark" :class="{ off: !recap.watermark_enabled }">
+							<span class="fu-recap-dot" :class="recap.watermark_enabled ? 'on' : 'off'"></span>
 							<span class="fu-recap-label">{{ __("Watermark") }}</span>
 							<span class="fu-recap-value">
-								{{ wm_enabled
-									? (watermark_settings && watermark_settings.mode === "Corner" ? __("Corner") : __("Tiled"))
+								{{ recap.watermark_enabled ? (recap.watermark_mode || "Tiled") : __("off") }}
+							</span>
+						</li>
+						<li v-if="show_comments" :class="{ off: !recap.comments_enabled }">
+							<span class="fu-recap-dot" :class="recap.comments_enabled ? 'on' : 'off'"></span>
+							<span class="fu-recap-label">{{ __("Comments") }}</span>
+							<span class="fu-recap-value">
+								{{ recap.comments_enabled
+									? (recap.comment_count ? __("{0} boxes", [recap.comment_count]) : __("on"))
 									: __("off") }}
 							</span>
 						</li>
-						<li v-if="show_comments" :class="{ off: !comments_enabled_default }">
-							<span class="fu-recap-dot" :class="comments_enabled_default ? 'on' : 'off'"></span>
-							<span class="fu-recap-label">{{ __("Comments") }}</span>
-							<span class="fu-recap-value">{{ comments_enabled_default ? __("on") : __("off") }}</span>
-						</li>
-						<li v-if="show_resize" :class="{ off: !resize_enabled_default }">
-							<span class="fu-recap-dot" :class="resize_enabled_default ? 'on' : 'off'"></span>
+						<li v-if="show_resize" :class="{ off: !recap.resize_enabled }">
+							<span class="fu-recap-dot" :class="recap.resize_enabled ? 'on' : 'off'"></span>
 							<span class="fu-recap-label">{{ __("Canvas") }}</span>
-							<span class="fu-recap-value">{{ resize_enabled_default ? (resize_settings && resize_settings.resize_aspect) || "1:1" : __("off") }}</span>
+							<span class="fu-recap-value">
+								{{ recap.resize_enabled ? recap.resize_aspect : __("off") }}
+							</span>
 						</li>
 					</ul>
 				</div>
@@ -277,7 +286,7 @@
 						:class="{ active: active_tab === tab.key }"
 						role="tab"
 						:aria-selected="active_tab === tab.key"
-						@click="active_tab = tab.key"
+						@click.stop.prevent="_switch_tab(tab.key)"
 					>
 						<span class="fu-feature-tab-label">{{ tab.label }}</span>
 						<span class="fu-feature-tab-state" :class="tab.on ? 'on' : 'off'">
@@ -323,15 +332,15 @@
 							<span class="fu-tab-enable-label">{{ __("Enable Watermark") }}</span>
 							<div
 								class="fu-toggle-pill"
-								:class="{ active: wm_enabled, 'is-disabled': !watermark_settings || !watermark_settings.watermark_image }"
-								@click="(watermark_settings && watermark_settings.watermark_image) && (wm_enabled = !wm_enabled)"
+								:class="{ active: wm_enabled, 'is-disabled': !local_watermark_settings || !local_watermark_settings.watermark_image }"
+								@click="(local_watermark_settings && local_watermark_settings.watermark_image) && (wm_enabled = !wm_enabled)"
 							>
 								<span class="fu-toggle-track" :class="{ on: wm_enabled }">
 									<span class="fu-toggle-thumb"></span>
 								</span>
 							</div>
 						</div>
-						<div v-if="!watermark_settings || !watermark_settings.watermark_image" class="fu-tab-note">
+						<div v-if="!local_watermark_settings || !local_watermark_settings.watermark_image" class="fu-tab-note">
 							{{ __("No watermark image uploaded.") }}
 							<a href="/app/watermark-settings">{{ __("Configure") }}</a>
 						</div>
@@ -340,78 +349,78 @@
 								<label class="fu-tab-field-label">{{ __("Mode") }}</label>
 								<div class="fu-seg-row">
 									<button type="button" class="fu-seg-btn"
-										:class="{ active: (watermark_settings.mode || 'Tiled') === 'Tiled' }"
+										:class="{ active: (local_watermark_settings.mode || 'Tiled') === 'Tiled' }"
 										@click="_set_wm_field('mode', 'Tiled')">{{ __("Tiled") }}</button>
 									<button type="button" class="fu-seg-btn"
-										:class="{ active: watermark_settings.mode === 'Corner' }"
+										:class="{ active: local_watermark_settings.mode === 'Corner' }"
 										@click="_set_wm_field('mode', 'Corner')">{{ __("Corner") }}</button>
 								</div>
 							</div>
-							<template v-if="(watermark_settings.mode || 'Tiled') === 'Tiled'">
+							<template v-if="(local_watermark_settings.mode || 'Tiled') === 'Tiled'">
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Opacity") }}</label>
 									<input type="range" class="fu-slider" min="5" max="100"
-										:value="watermark_settings.tile_opacity || 12"
+										:value="local_watermark_settings.tile_opacity || 12"
 										@input="_set_wm_field('tile_opacity', parseInt($event.target.value))" />
-									<span class="fu-slider-value">{{ watermark_settings.tile_opacity || 12 }}%</span>
+									<span class="fu-slider-value">{{ local_watermark_settings.tile_opacity || 12 }}%</span>
 								</div>
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Tile Size") }}</label>
 									<input type="range" class="fu-slider" min="5" max="80"
-										:value="watermark_settings.tile_size || 15"
+										:value="local_watermark_settings.tile_size || 15"
 										@input="_set_wm_field('tile_size', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(watermark_settings.tile_size || 15) }}%</span>
+									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.tile_size || 15) }}%</span>
 								</div>
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Rotation") }}</label>
 									<input type="range" class="fu-slider" min="-180" max="180"
-										:value="watermark_settings.tile_rotation != null ? watermark_settings.tile_rotation : -30"
+										:value="local_watermark_settings.tile_rotation != null ? local_watermark_settings.tile_rotation : -30"
 										@input="_set_wm_field('tile_rotation', parseInt($event.target.value))" />
-									<span class="fu-slider-value">{{ watermark_settings.tile_rotation != null ? watermark_settings.tile_rotation : -30 }}°</span>
+									<span class="fu-slider-value">{{ local_watermark_settings.tile_rotation != null ? local_watermark_settings.tile_rotation : -30 }}°</span>
 								</div>
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Spacing") }}</label>
 									<input type="range" class="fu-slider" min="0" max="100"
-										:value="watermark_settings.tile_spacing || 40"
+										:value="local_watermark_settings.tile_spacing || 40"
 										@input="_set_wm_field('tile_spacing', parseInt($event.target.value))" />
-									<span class="fu-slider-value">{{ watermark_settings.tile_spacing || 40 }}%</span>
+									<span class="fu-slider-value">{{ local_watermark_settings.tile_spacing || 40 }}%</span>
 								</div>
 							</template>
 							<template v-else>
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Opacity") }}</label>
 									<input type="range" class="fu-slider" min="5" max="100"
-										:value="watermark_settings.opacity || 50"
+										:value="local_watermark_settings.opacity || 50"
 										@input="_set_wm_field('opacity', parseInt($event.target.value))" />
-									<span class="fu-slider-value">{{ watermark_settings.opacity || 50 }}%</span>
+									<span class="fu-slider-value">{{ local_watermark_settings.opacity || 50 }}%</span>
 								</div>
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Size") }}</label>
 									<input type="range" class="fu-slider" min="5" max="100"
-										:value="watermark_settings.size || 20"
+										:value="local_watermark_settings.size || 20"
 										@input="_set_wm_field('size', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(watermark_settings.size || 20) }}%</span>
+									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.size || 20) }}%</span>
 								</div>
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Position X") }}</label>
 									<input type="range" class="fu-slider" min="0" max="100"
-										:value="watermark_settings.position_x || 80"
+										:value="local_watermark_settings.position_x || 80"
 										@input="_set_wm_field('position_x', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(watermark_settings.position_x || 80) }}%</span>
+									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.position_x || 80) }}%</span>
 								</div>
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Position Y") }}</label>
 									<input type="range" class="fu-slider" min="0" max="100"
-										:value="watermark_settings.position_y || 90"
+										:value="local_watermark_settings.position_y || 90"
 										@input="_set_wm_field('position_y', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(watermark_settings.position_y || 90) }}%</span>
+									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.position_y || 90) }}%</span>
 								</div>
 								<div class="fu-slider-row">
 									<label class="fu-slider-label">{{ __("Rotation") }}</label>
 									<input type="range" class="fu-slider" min="-180" max="180" step="5"
-										:value="watermark_settings.corner_rotation || 0"
+										:value="local_watermark_settings.corner_rotation || 0"
 										@input="_set_wm_field('corner_rotation', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(watermark_settings.corner_rotation || 0) }}°</span>
+									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.corner_rotation || 0) }}°</span>
 								</div>
 							</template>
 						</template>
@@ -431,12 +440,12 @@
 								</span>
 							</div>
 						</div>
-						<template v-if="comments_enabled_default && comment_defaults">
+						<template v-if="comments_enabled_default && local_comment_defaults">
 							<div class="fu-tab-note">{{ __("Default style for new comment boxes:") }}</div>
 							<div class="fu-tab-field">
 								<label class="fu-tab-field-label">{{ __("Font") }}</label>
 								<select class="fu-select"
-									:value="comment_defaults.font_family || 'Arial'"
+									:value="local_comment_defaults.font_family || 'Arial'"
 									@change="_set_comment_default('font_family', $event.target.value)">
 									<option v-for="f in ['Arial', 'Helvetica', 'Times New Roman', 'Courier New', 'Georgia', 'Verdana']" :key="f" :value="f">{{ f }}</option>
 								</select>
@@ -444,27 +453,27 @@
 							<div class="fu-slider-row">
 								<label class="fu-slider-label">{{ __("Size") }}</label>
 								<input type="range" class="fu-slider" min="1" max="20" step="0.5"
-									:value="comment_defaults.font_size_pct || 5"
+									:value="local_comment_defaults.font_size_pct || 5"
 									@input="_set_comment_default('font_size_pct', parseFloat($event.target.value))" />
-								<span class="fu-slider-value">{{ (comment_defaults.font_size_pct || 5).toFixed(1) }}%</span>
+								<span class="fu-slider-value">{{ (local_comment_defaults.font_size_pct || 5).toFixed(1) }}%</span>
 							</div>
 							<div class="fu-inline-field-row">
 								<label class="fu-inline-check">
 									<input type="checkbox"
-										:checked="comment_defaults.font_weight === 'Bold'"
+										:checked="local_comment_defaults.font_weight === 'Bold'"
 										@change="_set_comment_default('font_weight', $event.target.checked ? 'Bold' : 'Normal')" />
 									<span>B</span>
 								</label>
 								<label class="fu-inline-check">
 									<input type="checkbox"
-										:checked="comment_defaults.font_style === 'Italic'"
+										:checked="local_comment_defaults.font_style === 'Italic'"
 										@change="_set_comment_default('font_style', $event.target.checked ? 'Italic' : 'Normal')" />
 									<span><em>I</em></span>
 								</label>
 								<label class="fu-inline-colour">
 									<span>{{ __("Color") }}</span>
 									<input type="color"
-										:value="comment_defaults.color || '#000000'"
+										:value="local_comment_defaults.color || '#000000'"
 										@input="_set_comment_default('color', $event.target.value)" />
 								</label>
 							</div>
@@ -473,7 +482,7 @@
 								<div class="fu-seg-row">
 									<button v-for="a in ['Left', 'Center', 'Right']" :key="a"
 										type="button" class="fu-seg-btn"
-										:class="{ active: (comment_defaults.align || 'Center') === a }"
+										:class="{ active: (local_comment_defaults.align || 'Center') === a }"
 										@click="_set_comment_default('align', a)">{{ __(a) }}</button>
 								</div>
 							</div>
@@ -494,13 +503,13 @@
 								</span>
 							</div>
 						</div>
-						<template v-if="resize_enabled_default && resize_settings">
+						<template v-if="resize_enabled_default && local_resize_settings">
 							<div class="fu-tab-field">
 								<label class="fu-tab-field-label">{{ __("Aspect") }}</label>
 								<div class="fu-seg-row">
 									<button v-for="opt in ['1:1', '4:3', '16:9', '3:2', '2:3', 'Free']" :key="opt"
 										type="button" class="fu-seg-btn"
-										:class="{ active: (resize_settings.resize_aspect || '1:1') === opt }"
+										:class="{ active: (local_resize_settings.resize_aspect || '1:1') === opt }"
 										@click="_set_canvas_aspect(opt)">{{ opt }}</button>
 								</div>
 							</div>
@@ -509,21 +518,21 @@
 								<div class="fu-seg-row">
 									<button v-for="opt in ['Contain', 'Cover', 'Stretch']" :key="opt"
 										type="button" class="fu-seg-btn"
-										:class="{ active: (resize_settings.resize_mode || 'Contain') === opt }"
+										:class="{ active: (local_resize_settings.resize_mode || 'Contain') === opt }"
 										@click="_set_canvas_mode(opt)">{{ __(opt) }}</button>
 								</div>
 							</div>
 							<div class="fu-inline-field-row">
 								<label class="fu-inline-check">
 									<input type="checkbox"
-										:checked="resize_settings.resize_flatten_rgb !== false"
+										:checked="local_resize_settings.resize_flatten_rgb !== false"
 										@change="_set_canvas_field('resize_flatten_rgb', $event.target.checked ? 1 : 0)" />
 									<span>{{ __("Solid Background") }}</span>
 								</label>
-								<label v-if="resize_settings.resize_flatten_rgb !== false" class="fu-inline-colour">
+								<label v-if="local_resize_settings.resize_flatten_rgb !== false" class="fu-inline-colour">
 									<span>{{ __("Color") }}</span>
 									<input type="color"
-										:value="resize_settings.resize_fill_color || '#FFFFFF'"
+										:value="local_resize_settings.resize_fill_color || '#FFFFFF'"
 										@input="_set_canvas_field('resize_fill_color', $event.target.value)" />
 								</label>
 							</div>
@@ -541,13 +550,13 @@
 			:remove_bg_checked="remove_bg_checked"
 			:remove_bg_padding_pct="step1_padding_pct"
 			:show_watermark="show_watermark"
-			:watermark_settings="watermark_settings"
+			:watermark_settings="local_watermark_settings"
 			:wm_default_enabled="wm_enabled"
 			:show_resize="show_resize"
-			:resize_settings="resize_settings"
+			:resize_settings="local_resize_settings"
 			:resize_default_enabled="resize_enabled_default"
 			:show_comments="show_comments"
-			:comment_defaults="comment_defaults"
+			:comment_defaults="local_comment_defaults"
 			:comment_presets="comment_presets"
 			:comments_default_enabled="comments_enabled_default"
 			@toggle_image_cropper="toggle_image_cropper(-1)"
@@ -556,6 +565,7 @@
 			@wm_enabled_changed="wm_enabled = $event"
 			@comments_enabled_changed="comments_enabled_default = $event"
 			@resize_enabled_changed="resize_enabled_default = $event"
+			@crop_committed="_on_crop_committed"
 		/>
 		<FileBrowser
 			ref="file_browser"
@@ -691,20 +701,39 @@ export default {
 			wm_enabled: this.watermark_settings && this.watermark_settings.enabled ? true : false,
 			// Pre-cropper toggles for Comments + Canvas so the file-picker
 			// page exposes the same 4 features the cropper tab-panel does.
-			// Actual application happens inside ImageCropper; these just
-			// carry the user's default toggle intent into the cropper.
 			comments_enabled_default: !!(this.comment_defaults && this.comment_defaults.enabled),
 			resize_enabled_default: !!(this.resize_settings && this.resize_settings.resize_enabled),
 			// Auto-crop padding — initial value comes from Image Processing
 			// Settings (remove_bg_padding_pct prop). User can override on
-			// Step 1 before picking a file; the value is passed into the
-			// cropper via the :remove_bg_padding_pct prop below, so the
-			// cropper initializes to whatever Step 1 last had.
+			// Step 1 before picking a file.
 			step1_padding_pct: this.remove_bg_padding_pct != null ? this.remove_bg_padding_pct : 2,
-			// Which right-panel tab is visible on Step 1. Reset in mounted()
-			// to the first-available feature so the pane doesn't open on a
-			// tab the consumer didn't opt into.
+			// Which right-panel tab is visible on Step 1.
 			active_tab: "remove_bg",
+			// Snapshot of the cropper's final feature states at the moment
+			// the user clicked Crop. Populated by @crop_committed so Step 3's
+			// recap card can display "exactly what was baked" rather than
+			// Step 1's pre-cropper defaults (which may have been edited
+			// inside the cropper).
+			last_crop_settings: null,
+			// ── Local editable copies of settings-prop objects ────────
+			// Props passed from index.js are plain JS objects cached on
+			// frappe._*_cache — NOT Vue-reactive. Mutating them via $set
+			// on a prop doesn't reliably trigger re-renders (Vue 2 warns
+			// "avoid mutating prop" and the parent never observed the
+			// nested keys). We deep-clone into local data so every
+			// <input :value> binding is fully reactive, then pass the
+			// local copy into ImageCropper as the :watermark_settings /
+			// :resize_settings / :comment_defaults props so Step 1 →
+			// Step 2 edits roundtrip cleanly.
+			local_watermark_settings: this.watermark_settings
+				? JSON.parse(JSON.stringify(this.watermark_settings))
+				: null,
+			local_resize_settings: this.resize_settings
+				? JSON.parse(JSON.stringify(this.resize_settings))
+				: null,
+			local_comment_defaults: this.comment_defaults
+				? JSON.parse(JSON.stringify(this.comment_defaults))
+				: null,
 		};
 	},
 	created() {
@@ -761,6 +790,29 @@ export default {
 			return !!(this.show_remove_bg || this.show_watermark
 				|| this.show_comments || this.show_resize);
 		},
+		// Step 3 recap view: prefer post-crop snapshot (last_crop_settings)
+		// so it reflects whatever the user committed in the cropper,
+		// falling back to Step 1 defaults before the first crop. One
+		// source so template binds stay readable.
+		recap() {
+			const s = this.last_crop_settings || {};
+			return {
+				remove_bg: s.remove_bg != null ? s.remove_bg : this.remove_bg_checked,
+				watermark_enabled: s.watermark_enabled != null ? s.watermark_enabled : this.wm_enabled,
+				watermark_mode: s.watermark_mode
+					|| (this.local_watermark_settings && this.local_watermark_settings.mode)
+					|| "Tiled",
+				comments_enabled: s.comments_enabled != null ? s.comments_enabled : this.comments_enabled_default,
+				comment_count: s.comment_count || 0,
+				resize_enabled: s.resize_enabled != null ? s.resize_enabled : this.resize_enabled_default,
+				resize_aspect: s.resize_aspect
+					|| (this.local_resize_settings && this.local_resize_settings.resize_aspect)
+					|| "1:1",
+				resize_mode: s.resize_mode
+					|| (this.local_resize_settings && this.local_resize_settings.resize_mode)
+					|| "Contain",
+			};
+		},
 		// Tab objects used by the v-for in the template. Each entry knows
 		// its ON state so the pill header can render the green/grey dot
 		// without the template having to branch on key.
@@ -811,25 +863,49 @@ export default {
 		// resize_settings, comment_defaults) are passed by reference from
 		// index.js, so $set here updates the cropper's initial values.
 
+		_switch_tab(key) {
+			this.active_tab = key;
+		},
+		_on_crop_committed(snapshot) {
+			this.last_crop_settings = snapshot;
+			// Keep Step 1 / recap toggle dots in sync with the cropper's
+			// final state so a user clicking Back sees what they last
+			// committed, not the pre-crop defaults.
+			this.remove_bg_checked = !!snapshot.remove_bg;
+			this.wm_enabled = !!snapshot.watermark_enabled;
+			this.comments_enabled_default = !!snapshot.comments_enabled;
+			this.resize_enabled_default = !!snapshot.resize_enabled;
+			if (this.local_watermark_settings && snapshot.watermark_mode) {
+				this.$set(this.local_watermark_settings, "mode", snapshot.watermark_mode);
+			}
+			if (this.local_resize_settings) {
+				if (snapshot.resize_aspect) {
+					this.$set(this.local_resize_settings, "resize_aspect", snapshot.resize_aspect);
+				}
+				if (snapshot.resize_mode) {
+					this.$set(this.local_resize_settings, "resize_mode", snapshot.resize_mode);
+				}
+			}
+		},
 		_set_wm_field(field, value) {
-			if (!this.watermark_settings) return;
-			this.$set(this.watermark_settings, field, value);
+			if (!this.local_watermark_settings) return;
+			this.$set(this.local_watermark_settings, field, value);
 		},
 		_set_comment_default(field, value) {
-			if (!this.comment_defaults) return;
-			this.$set(this.comment_defaults, field, value);
+			if (!this.local_comment_defaults) return;
+			this.$set(this.local_comment_defaults, field, value);
 		},
 		_set_canvas_aspect(opt) {
-			if (!this.resize_settings) return;
-			this.$set(this.resize_settings, "resize_aspect", opt);
+			if (!this.local_resize_settings) return;
+			this.$set(this.local_resize_settings, "resize_aspect", opt);
 		},
 		_set_canvas_mode(opt) {
-			if (!this.resize_settings) return;
-			this.$set(this.resize_settings, "resize_mode", opt);
+			if (!this.local_resize_settings) return;
+			this.$set(this.local_resize_settings, "resize_mode", opt);
 		},
 		_set_canvas_field(field, value) {
-			if (!this.resize_settings) return;
-			this.$set(this.resize_settings, field, value);
+			if (!this.local_resize_settings) return;
+			this.$set(this.local_resize_settings, field, value);
 		},
 		dragover() {
 			this.is_dragging = true;

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -444,7 +444,14 @@
 						</div>
 					</div>
 
-					<!-- ── COMMENTS pane ── -->
+					<!-- ── COMMENTS pane ──
+					     Reuses the CommentBoxEditor component in sidebar-only
+					     mode (hide-canvas) so Step 1 shares the same list +
+					     per-box form + two-tier Save/Reset as Step 2's cropper
+					     and the batch Header / Row editors. The box list is
+					     carried into the cropper via :initial_comment_boxes,
+					     so any boxes the user builds here are waiting on Step
+					     2 when they pick a file. -->
 					<div v-show="active_tab === 'comments'" class="cropper-tab-pane">
 						<div class="cropper-tab-enable">
 							<span class="cropper-tab-enable-label">{{ __("Enable Comments") }}</span>
@@ -460,55 +467,16 @@
 								</span>
 							</div>
 						</div>
-						<div v-if="comments_enabled_default && local_comment_defaults" class="adjustments-row">
-							<label class="adjustments-field-label">{{ __("Default style for new comment boxes") }}</label>
-							<div class="wm-slider-row">
-								<label class="wm-slider-label">{{ __("Font") }}</label>
-								<select class="wm-select-inline"
-									:value="local_comment_defaults.font_family || 'Arial'"
-									@change="_set_comment_default('font_family', $event.target.value)">
-									<option v-for="f in ['Arial', 'Helvetica', 'Times New Roman', 'Courier New', 'Georgia', 'Verdana']" :key="f" :value="f">{{ f }}</option>
-								</select>
-							</div>
-							<div class="wm-slider-row">
-								<label class="wm-slider-label">{{ __("Size") }}</label>
-								<input type="range" class="wm-slider" min="1" max="20" step="0.5"
-									:value="local_comment_defaults.font_size_pct || 5"
-									@input="_set_comment_default('font_size_pct', parseFloat($event.target.value))" />
-								<span class="wm-slider-value">{{ (local_comment_defaults.font_size_pct || 5).toFixed(1) }}%</span>
-							</div>
-							<div class="wm-inline-row">
-								<label class="wm-inline-check">
-									<input type="checkbox"
-										:checked="local_comment_defaults.font_weight === 'Bold'"
-										@change="_set_comment_default('font_weight', $event.target.checked ? 'Bold' : 'Normal')" />
-									<span><strong>B</strong></span>
-								</label>
-								<label class="wm-inline-check">
-									<input type="checkbox"
-										:checked="local_comment_defaults.font_style === 'Italic'"
-										@change="_set_comment_default('font_style', $event.target.checked ? 'Italic' : 'Normal')" />
-									<span><em>I</em></span>
-								</label>
-								<label class="wm-inline-colour">
-									<span>{{ __("Color") }}</span>
-									<input type="color"
-										:value="local_comment_defaults.color || '#000000'"
-										@input="_set_comment_default('color', $event.target.value)" />
-								</label>
-							</div>
-							<label class="adjustments-field-label" style="margin-top:8px">{{ __("Align") }}</label>
-							<div class="segmented-tabs" role="tablist">
-								<button v-for="a in ['Left', 'Center', 'Right']" :key="a"
-									type="button" class="segmented-tab"
-									:class="{ active: (local_comment_defaults.align || 'Center') === a }"
-									@click="_set_comment_default('align', a)">{{ __(a) }}</button>
-							</div>
-							<div class="wm-panel-actions">
-								<button class="btn btn-xs btn-default" @click="_reset_comment_default">{{ __("Reset") }}</button>
-								<button class="btn btn-xs btn-primary-light" @click="_save_comment_default">{{ __("Save as Default") }}</button>
-							</div>
-						</div>
+						<CommentBoxEditor
+							v-if="comments_enabled_default"
+							hide-canvas
+							:boxes="step1_comment_boxes"
+							:presets="comment_presets || []"
+							:defaults="local_comment_defaults || {}"
+							:enabled="comments_enabled_default"
+							@change="step1_comment_boxes = $event"
+							@reset-enabled="comments_enabled_default = !!(comment_defaults && comment_defaults.enabled)"
+						/>
 					</div>
 
 					<!-- ── CANVAS pane ── -->
@@ -583,6 +551,7 @@
 			:comment_defaults="local_comment_defaults"
 			:comment_presets="comment_presets"
 			:comments_default_enabled="comments_enabled_default"
+			:initial_comment_boxes="step1_comment_boxes"
 			@toggle_image_cropper="toggle_image_cropper(-1)"
 			@upload_after_crop="trigger_upload = true"
 			@remove_bg_changed="remove_bg_checked = $event"
@@ -606,6 +575,12 @@ import FileBrowser from "./FileBrowser.vue";
 import WebLink from "./WebLink.vue";
 import GoogleDrivePicker from "../../integrations/google_drive_picker";
 import ImageCropper from "./ImageCropper.vue";
+// Cross-app import: CommentBoxEditor lives in the next app because
+// it's also used by the batch view. esbuild's NODE_PATHS resolves
+// `next/...` at build time. Step 1 renders it in sidebar-only mode
+// (hideCanvas) so users can build the comment list even before an
+// image is picked.
+import CommentBoxEditor from "next/public/js/item_image_batch/CommentBoxEditor.vue";
 
 export default {
 	name: "FileUploader",
@@ -702,6 +677,7 @@ export default {
 		FileBrowser,
 		WebLink,
 		ImageCropper,
+		CommentBoxEditor,
 	},
 	data() {
 		return {
@@ -727,6 +703,13 @@ export default {
 			// page exposes the same 4 features the cropper tab-panel does.
 			comments_enabled_default: !!(this.comment_defaults && this.comment_defaults.enabled),
 			resize_enabled_default: !!(this.resize_settings && this.resize_settings.resize_enabled),
+			// Step-1 comment box list, seeded from Settings.comment_presets
+			// so "Save as Default" and the initial hydrated list stay in
+			// sync. Any edits here carry over into the cropper's Step 2
+			// via the :initial_comment_boxes prop on ImageCropper.
+			step1_comment_boxes: Array.isArray(this.comment_presets)
+				? this.comment_presets.map((p) => ({ ...p }))
+				: [],
 			// Auto-crop padding — initial value comes from Image Processing
 			// Settings (remove_bg_padding_pct prop). User can override on
 			// Step 1 before picking a file.
@@ -945,15 +928,24 @@ export default {
 			frappe.show_alert({ message: __("Reset to saved defaults"), indicator: "blue" });
 		},
 		_save_bg_default() {
+			// Save both the enable toggle AND the padding so "Save as
+			// Default" reflects the full Remove BG tab state. Matches the
+			// behavior of the Canvas tab (which also persists its enable
+			// flag). Remove BG availability on the site might still
+			// override this to false at load time if the microservice
+			// isn't configured.
 			frappe.call({
 				method: "frappe.client.set_value",
 				args: {
 					doctype: "Image Processing Settings",
 					name: "Image Processing Settings",
-					fieldname: { remove_bg_padding_pct: this.step1_padding_pct },
+					fieldname: {
+						remove_bg_enabled: this.remove_bg_checked ? 1 : 0,
+						remove_bg_padding_pct: this.step1_padding_pct,
+					},
 				},
 			}).then(() => {
-				frappe.show_alert({ message: __("Auto-crop padding saved as default"), indicator: "green" });
+				frappe.show_alert({ message: __("Remove BG defaults saved"), indicator: "green" });
 			}).catch(() => {
 				frappe.show_alert({ message: __("Failed to save default"), indicator: "red" });
 			});
@@ -967,12 +959,16 @@ export default {
 		_save_wm_default() {
 			const s = this.local_watermark_settings;
 			if (!s) return;
+			// Save both the Enable Watermark toggle (Watermark Settings.enabled)
+			// AND all Tiled/Corner params so next upload opens with the same
+			// state the user just configured.
 			frappe.call({
 				method: "frappe.client.set_value",
 				args: {
 					doctype: "Watermark Settings",
 					name: "Watermark Settings",
 					fieldname: {
+						enabled: this.wm_enabled ? 1 : 0,
 						mode: s.mode || "Tiled",
 						position_x: s.position_x != null ? s.position_x : 80,
 						position_y: s.position_y != null ? s.position_y : 90,
@@ -990,6 +986,7 @@ export default {
 				// the new defaults without a page reload.
 				if (frappe._watermark_settings_cache) {
 					Object.assign(frappe._watermark_settings_cache, s);
+					frappe._watermark_settings_cache.enabled = !!this.wm_enabled;
 				}
 				frappe.show_alert({ message: __("Watermark defaults saved"), indicator: "green" });
 			}).catch(() => {
@@ -1005,12 +1002,17 @@ export default {
 		_save_comment_default() {
 			const c = this.local_comment_defaults;
 			if (!c) return;
+			// Save enable state too so "Save as Default" is truly the full
+			// tab state. default_comments_enabled was added to Image
+			// Processing Settings specifically to carry this flag; see
+			// image_processing_settings.json.
 			frappe.call({
 				method: "frappe.client.set_value",
 				args: {
 					doctype: "Image Processing Settings",
 					name: "Image Processing Settings",
 					fieldname: {
+						default_comments_enabled: this.comments_enabled_default ? 1 : 0,
 						default_comment_font_family: c.font_family || "Arial",
 						default_comment_font_size_pct: c.font_size_pct || 5,
 						default_comment_font_weight: c.font_weight || "Normal",

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -1,10 +1,15 @@
 <template>
 	<div
 		class="file-uploader"
+		:class="{
+			'fu-with-panel': any_feature_shown && !show_image_cropper && !show_file_browser && !show_web_link,
+		}"
 		@dragover.prevent="dragover"
 		@dragleave.prevent="dragleave"
 		@drop.prevent="dropfiles"
 	>
+		<!-- LEFT COLUMN: dropzone (step 1) OR file list (step 3) -->
+		<div class="fu-left-col">
 		<div
 			class="file-upload-area"
 			v-show="files.length === 0 && !show_file_browser && !show_web_link"
@@ -214,6 +219,186 @@
 				</div>
 			</div>
 		</div>
+		</div><!-- /.fu-left-col -->
+
+		<!-- RIGHT COLUMN: feature tabs + pane OR recap card
+		     Only rendered outside the cropper step (cropper has its own
+		     identical panel). Hidden entirely when no feature was
+		     requested, so non-image uploads keep the simple single-column
+		     layout that Frappe's default uploader has. -->
+		<div
+			class="fu-right-col"
+			v-if="any_feature_shown && !show_image_cropper && !show_file_browser && !show_web_link"
+		>
+			<!-- Step 3 (files added, crop committed): read-only recap -->
+			<template v-if="files.length > 0">
+				<div class="fu-recap-card">
+					<div class="fu-recap-title">{{ __("Applied to your image") }}</div>
+					<div class="fu-recap-hint">{{ __("Locked in at the Crop step — cannot be edited after upload.") }}</div>
+					<ul class="fu-recap-list">
+						<li v-if="show_remove_bg" :class="{ off: !remove_bg_checked }">
+							<span class="fu-recap-dot" :class="remove_bg_checked ? 'on' : 'off'"></span>
+							<span class="fu-recap-label">{{ __("Remove Background") }}</span>
+							<span class="fu-recap-value">{{ remove_bg_checked ? __("on") : __("off") }}</span>
+						</li>
+						<li v-if="show_watermark" :class="{ off: !wm_enabled }">
+							<span class="fu-recap-dot" :class="wm_enabled ? 'on' : 'off'"></span>
+							<span class="fu-recap-label">{{ __("Watermark") }}</span>
+							<span class="fu-recap-value">
+								{{ wm_enabled
+									? (watermark_settings && watermark_settings.mode === "Corner" ? __("Corner") : __("Tiled"))
+									: __("off") }}
+							</span>
+						</li>
+						<li v-if="show_comments" :class="{ off: !comments_enabled_default }">
+							<span class="fu-recap-dot" :class="comments_enabled_default ? 'on' : 'off'"></span>
+							<span class="fu-recap-label">{{ __("Comments") }}</span>
+							<span class="fu-recap-value">{{ comments_enabled_default ? __("on") : __("off") }}</span>
+						</li>
+						<li v-if="show_resize" :class="{ off: !resize_enabled_default }">
+							<span class="fu-recap-dot" :class="resize_enabled_default ? 'on' : 'off'"></span>
+							<span class="fu-recap-label">{{ __("Canvas") }}</span>
+							<span class="fu-recap-value">{{ resize_enabled_default ? (resize_settings && resize_settings.resize_aspect) || "1:1" : __("off") }}</span>
+						</li>
+					</ul>
+				</div>
+			</template>
+
+			<!-- Step 1 (no files yet): interactive 4-tab panel -->
+			<template v-else>
+				<div class="fu-feature-tabs" role="tablist">
+					<button
+						v-for="tab in available_tabs"
+						:key="tab.key"
+						type="button"
+						class="fu-feature-tab"
+						:class="{ active: active_tab === tab.key }"
+						role="tab"
+						:aria-selected="active_tab === tab.key"
+						@click="active_tab = tab.key"
+					>
+						<span class="fu-feature-tab-label">{{ tab.label }}</span>
+						<span class="fu-feature-tab-state" :class="tab.on ? 'on' : 'off'">
+							<span class="fu-feature-tab-dot"></span>
+							{{ tab.on ? __("on") : __("off") }}
+						</span>
+					</button>
+				</div>
+
+				<div class="fu-tab-body">
+					<!-- REMOVE BG pane -->
+					<div v-show="active_tab === 'remove_bg'" class="fu-tab-pane">
+						<div class="fu-tab-enable">
+							<span class="fu-tab-enable-label">{{ __("Enable Remove Background") }}</span>
+							<div
+								class="fu-toggle-pill"
+								:class="{ active: remove_bg_checked, 'is-disabled': !!remove_bg_disabled_hint }"
+								@click="!remove_bg_disabled_hint && (remove_bg_checked = !remove_bg_checked)"
+							>
+								<span class="fu-toggle-track" :class="{ on: remove_bg_checked && !remove_bg_disabled_hint }">
+									<span class="fu-toggle-thumb"></span>
+								</span>
+							</div>
+						</div>
+						<div v-if="remove_bg_disabled_hint" class="fu-tab-note">
+							{{ remove_bg_disabled_hint }}
+							<a v-if="remove_bg_disabled_link" :href="remove_bg_disabled_link">{{ __("Configure") }}</a>
+						</div>
+						<div v-else class="fu-tab-note">
+							{{ __("Auto-crop padding + mask preview available after adding a file.") }}
+						</div>
+					</div>
+
+					<!-- WATERMARK pane -->
+					<div v-show="active_tab === 'watermark'" class="fu-tab-pane">
+						<div class="fu-tab-enable">
+							<span class="fu-tab-enable-label">{{ __("Enable Watermark") }}</span>
+							<div
+								class="fu-toggle-pill"
+								:class="{ active: wm_enabled, 'is-disabled': !watermark_settings || !watermark_settings.watermark_image }"
+								@click="(watermark_settings && watermark_settings.watermark_image) && (wm_enabled = !wm_enabled)"
+							>
+								<span class="fu-toggle-track" :class="{ on: wm_enabled }">
+									<span class="fu-toggle-thumb"></span>
+								</span>
+							</div>
+						</div>
+						<div v-if="!watermark_settings || !watermark_settings.watermark_image" class="fu-tab-note">
+							{{ __("No watermark image uploaded.") }}
+							<a href="/app/watermark-settings">{{ __("Configure") }}</a>
+						</div>
+						<div v-else class="fu-tab-note">
+							{{ __("Mode: {0}. Position, size and rotation are editable in the Crop step.", [(watermark_settings && watermark_settings.mode) || "Tiled"]) }}
+						</div>
+					</div>
+
+					<!-- COMMENTS pane -->
+					<div v-show="active_tab === 'comments'" class="fu-tab-pane">
+						<div class="fu-tab-enable">
+							<span class="fu-tab-enable-label">{{ __("Enable Comments") }}</span>
+							<div
+								class="fu-toggle-pill"
+								:class="{ active: comments_enabled_default }"
+								@click="comments_enabled_default = !comments_enabled_default"
+							>
+								<span class="fu-toggle-track" :class="{ on: comments_enabled_default }">
+									<span class="fu-toggle-thumb"></span>
+								</span>
+							</div>
+						</div>
+						<div class="fu-tab-note">
+							{{ __("Add, position and style text overlays in the Crop step.") }}
+						</div>
+					</div>
+
+					<!-- CANVAS pane (aspect + mode are editable here, baked later) -->
+					<div v-show="active_tab === 'canvas'" class="fu-tab-pane">
+						<div class="fu-tab-enable">
+							<span class="fu-tab-enable-label">{{ __("Enable Canvas normalization") }}</span>
+							<div
+								class="fu-toggle-pill"
+								:class="{ active: resize_enabled_default }"
+								@click="resize_enabled_default = !resize_enabled_default"
+							>
+								<span class="fu-toggle-track" :class="{ on: resize_enabled_default }">
+									<span class="fu-toggle-thumb"></span>
+								</span>
+							</div>
+						</div>
+						<div v-if="resize_enabled_default && resize_settings" class="fu-tab-field">
+							<label class="fu-tab-field-label">{{ __("Aspect") }}</label>
+							<div class="fu-seg-row">
+								<button
+									v-for="opt in ['1:1', '4:3', '16:9', '3:2', '2:3', 'Free']"
+									:key="opt"
+									type="button"
+									class="fu-seg-btn"
+									:class="{ active: (resize_settings.resize_aspect || '1:1') === opt }"
+									@click="_set_canvas_aspect(opt)"
+								>{{ opt }}</button>
+							</div>
+						</div>
+						<div v-if="resize_enabled_default && resize_settings" class="fu-tab-field">
+							<label class="fu-tab-field-label">{{ __("Mode") }}</label>
+							<div class="fu-seg-row">
+								<button
+									v-for="opt in ['Contain', 'Cover', 'Stretch']"
+									:key="opt"
+									type="button"
+									class="fu-seg-btn"
+									:class="{ active: (resize_settings.resize_mode || 'Contain') === opt }"
+									@click="_set_canvas_mode(opt)"
+								>{{ __(opt) }}</button>
+							</div>
+						</div>
+						<div v-else class="fu-tab-note">
+							{{ __("Resize, background color and file-size cap are configurable in the Crop step.") }}
+						</div>
+					</div>
+				</div>
+			</template>
+		</div><!-- /.fu-right-col -->
+
 		<ImageCropper
 			v-if="show_image_cropper && wrapper_ready"
 			:file="files[crop_image_with_index]"
@@ -376,6 +561,10 @@ export default {
 			// carry the user's default toggle intent into the cropper.
 			comments_enabled_default: !!(this.comment_defaults && this.comment_defaults.enabled),
 			resize_enabled_default: !!(this.resize_settings && this.resize_settings.resize_enabled),
+			// Which right-panel tab is visible on Step 1. Reset in mounted()
+			// to the first-available feature so the pane doesn't open on a
+			// tab the consumer didn't opt into.
+			active_tab: "remove_bg",
 		};
 	},
 	created() {
@@ -424,8 +613,68 @@ export default {
 				this.files.every((file) => file.total !== 0 && file.progress === file.total)
 			);
 		},
+		// At least one of the 4 image-processing features was opted-in by
+		// the caller. Controls whether the right-side panel renders at all
+		// — a plain Attachment upload (no image processing) stays
+		// single-column like the original Frappe uploader.
+		any_feature_shown() {
+			return !!(this.show_remove_bg || this.show_watermark
+				|| this.show_comments || this.show_resize);
+		},
+		// Tab objects used by the v-for in the template. Each entry knows
+		// its ON state so the pill header can render the green/grey dot
+		// without the template having to branch on key.
+		available_tabs() {
+			const tabs = [];
+			if (this.show_remove_bg) {
+				tabs.push({
+					key: "remove_bg",
+					label: __("Remove BG"),
+					on: !!this.remove_bg_checked && !this.remove_bg_disabled_hint,
+				});
+			}
+			if (this.show_watermark) {
+				tabs.push({
+					key: "watermark",
+					label: __("Watermark"),
+					on: !!this.wm_enabled,
+				});
+			}
+			if (this.show_comments) {
+				tabs.push({
+					key: "comments",
+					label: __("Comments"),
+					on: !!this.comments_enabled_default,
+				});
+			}
+			if (this.show_resize) {
+				tabs.push({
+					key: "canvas",
+					label: __("Canvas"),
+					on: !!this.resize_enabled_default,
+				});
+			}
+			return tabs;
+		},
+	},
+	mounted() {
+		// Reset active_tab to the first available feature, so the panel
+		// doesn't land on a tab the consumer didn't opt into.
+		const first = this.available_tabs[0];
+		if (first) this.active_tab = first.key;
 	},
 	methods: {
+		// Canvas (Resize) aspect + mode editors for Step 1. We mutate the
+		// resize_settings object in place so the cropper picks up the
+		// latest values via its own prop watcher when the user clicks Crop.
+		_set_canvas_aspect(opt) {
+			if (!this.resize_settings) return;
+			this.$set(this.resize_settings, "resize_aspect", opt);
+		},
+		_set_canvas_mode(opt) {
+			if (!this.resize_settings) return;
+			this.$set(this.resize_settings, "resize_mode", opt);
+		},
 		dragover() {
 			this.is_dragging = true;
 		},
@@ -798,6 +1047,256 @@ export default {
 };
 </script>
 <style>
+/* ── 2-column grid for Step 1 + Step 3 ──────────────────────────────
+   The uploader auto-splits into a left column (dropzone / file list)
+   and a right column (feature-tabs / recap) when the caller opts into
+   any image-processing feature. Plain attachment uploads (no features)
+   still render single-column like the original Frappe dialog. The
+   cropper step switches off the grid via .fu-cropper-mode so it can
+   use its own internal layout.
+-------------------------------------------------------------------- */
+.file-uploader { display: block; }
+.file-uploader.fu-with-panel {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 320px;
+	gap: 16px;
+	align-items: start;
+}
+.file-uploader .fu-left-col { min-width: 0; }
+.file-uploader .fu-right-col {
+	position: sticky;
+	top: 0;
+	border: 1px solid var(--border-color);
+	border-radius: 10px;
+	background: #fff;
+	padding: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+/* Tab header strip ─ matches the cropper's .cropper-feature-tabs
+   visual style so Step 1 and Step 2 look like the same control. */
+.fu-feature-tabs {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
+	gap: 4px;
+	background: #f1f5f9;
+	border-radius: 8px;
+	padding: 4px;
+}
+.fu-feature-tab {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 3px;
+	padding: 8px 6px;
+	background: transparent;
+	border: none;
+	border-radius: 6px;
+	cursor: pointer;
+	color: #64748b;
+	font-size: 12px;
+	transition: background 0.15s ease, color 0.15s ease;
+}
+.fu-feature-tab:hover { background: rgba(255, 255, 255, 0.55); }
+.fu-feature-tab.active {
+	background: #fff;
+	color: var(--primary);
+	box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+.fu-feature-tab-label {
+	font-weight: 600;
+	font-size: 11px;
+	line-height: 1.2;
+}
+.fu-feature-tab-state {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	font-size: 10px;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.02em;
+}
+.fu-feature-tab-state.on { color: #10b981; }
+.fu-feature-tab-state.off { color: #94a3b8; }
+.fu-feature-tab-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: currentColor;
+}
+
+.fu-tab-body { flex: 1 1 auto; }
+.fu-tab-pane {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+.fu-tab-enable {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 10px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: #fafbfc;
+}
+.fu-tab-enable-label {
+	font-size: 13px;
+	font-weight: 600;
+	color: #303133;
+}
+.fu-tab-note {
+	font-size: 12px;
+	color: var(--text-muted);
+	line-height: 1.5;
+	padding: 8px 10px;
+	background: #f8fafc;
+	border-radius: 6px;
+}
+.fu-tab-note a {
+	color: var(--primary);
+	text-decoration: underline;
+	margin-left: 4px;
+}
+.fu-tab-field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.fu-tab-field-label {
+	font-size: 11px;
+	font-weight: 600;
+	color: #475569;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	margin: 0;
+}
+.fu-seg-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+}
+.fu-seg-btn {
+	padding: 4px 10px;
+	font-size: 12px;
+	font-weight: 500;
+	color: #475569;
+	background: #fff;
+	border: 1px solid var(--border-color);
+	border-radius: 4px;
+	cursor: pointer;
+	transition: all 0.15s ease;
+}
+.fu-seg-btn:hover { border-color: var(--primary); }
+.fu-seg-btn.active {
+	background: var(--primary);
+	color: #fff;
+	border-color: var(--primary);
+}
+
+/* Toggle pill — same look as the cropper's compact toggle */
+.fu-toggle-pill {
+	display: inline-flex;
+	align-items: center;
+	cursor: pointer;
+}
+.fu-toggle-pill.is-disabled {
+	cursor: not-allowed;
+	opacity: 0.55;
+}
+.fu-toggle-track {
+	display: inline-block;
+	width: 30px;
+	height: 16px;
+	border-radius: 8px;
+	background: #cbd5e1;
+	position: relative;
+	transition: background 0.2s ease;
+}
+.fu-toggle-track.on { background: var(--primary); }
+.fu-toggle-thumb {
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	background: #fff;
+	transition: transform 0.2s ease;
+}
+.fu-toggle-track.on .fu-toggle-thumb { transform: translateX(14px); }
+
+/* ── Recap card (Step 3) ────────────────────────────────────────── */
+.fu-recap-card {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.fu-recap-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: #0f172a;
+}
+.fu-recap-hint {
+	font-size: 11px;
+	color: var(--text-muted);
+	margin-bottom: 8px;
+}
+.fu-recap-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+.fu-recap-list li {
+	display: grid;
+	grid-template-columns: 10px 1fr auto;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 10px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: #fafbfc;
+	font-size: 12px;
+}
+.fu-recap-list li.off {
+	background: #f8fafc;
+	color: #94a3b8;
+}
+.fu-recap-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+}
+.fu-recap-dot.on  { background: #10b981; }
+.fu-recap-dot.off { background: #cbd5e1; }
+.fu-recap-label { font-weight: 500; }
+.fu-recap-value {
+	font-size: 11px;
+	color: #64748b;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+}
+
+/* ── Mobile: stack right column below left ─────────────────────── */
+@media (max-width: 768px) {
+	.file-uploader.fu-with-panel {
+		grid-template-columns: 1fr;
+	}
+	.file-uploader .fu-right-col {
+		position: static;
+	}
+	.fu-feature-tabs {
+		grid-template-columns: repeat(4, 1fr);
+	}
+}
+
 .file-upload-area {
 	min-height: 20rem;
 	display: flex;

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -264,7 +264,9 @@
 				</div>
 			</template>
 
-			<!-- Step 1 (no files yet): interactive 4-tab panel -->
+			<!-- Step 1 (no files yet): interactive 4-tab panel — full
+			     editable params, mirroring the cropper's right panel so
+			     users can set their defaults before picking a file. -->
 			<template v-else>
 				<div class="fu-feature-tabs" role="tablist">
 					<button
@@ -286,7 +288,7 @@
 				</div>
 
 				<div class="fu-tab-body">
-					<!-- REMOVE BG pane -->
+					<!-- ── REMOVE BG pane ── -->
 					<div v-show="active_tab === 'remove_bg'" class="fu-tab-pane">
 						<div class="fu-tab-enable">
 							<span class="fu-tab-enable-label">{{ __("Enable Remove Background") }}</span>
@@ -304,12 +306,18 @@
 							{{ remove_bg_disabled_hint }}
 							<a v-if="remove_bg_disabled_link" :href="remove_bg_disabled_link">{{ __("Configure") }}</a>
 						</div>
-						<div v-else class="fu-tab-note">
-							{{ __("Auto-crop padding + mask preview available after adding a file.") }}
-						</div>
+						<template v-else>
+							<div class="fu-slider-row">
+								<label class="fu-slider-label">{{ __("Auto-crop padding") }}</label>
+								<input type="range" class="fu-slider" min="-20" max="40" step="1"
+									:value="step1_padding_pct"
+									@input="step1_padding_pct = parseInt($event.target.value)" />
+								<span class="fu-slider-value">{{ step1_padding_pct }}%</span>
+							</div>
+						</template>
 					</div>
 
-					<!-- WATERMARK pane -->
+					<!-- ── WATERMARK pane ── -->
 					<div v-show="active_tab === 'watermark'" class="fu-tab-pane">
 						<div class="fu-tab-enable">
 							<span class="fu-tab-enable-label">{{ __("Enable Watermark") }}</span>
@@ -327,12 +335,89 @@
 							{{ __("No watermark image uploaded.") }}
 							<a href="/app/watermark-settings">{{ __("Configure") }}</a>
 						</div>
-						<div v-else class="fu-tab-note">
-							{{ __("Mode: {0}. Position, size and rotation are editable in the Crop step.", [(watermark_settings && watermark_settings.mode) || "Tiled"]) }}
-						</div>
+						<template v-else-if="wm_enabled">
+							<div class="fu-tab-field">
+								<label class="fu-tab-field-label">{{ __("Mode") }}</label>
+								<div class="fu-seg-row">
+									<button type="button" class="fu-seg-btn"
+										:class="{ active: (watermark_settings.mode || 'Tiled') === 'Tiled' }"
+										@click="_set_wm_field('mode', 'Tiled')">{{ __("Tiled") }}</button>
+									<button type="button" class="fu-seg-btn"
+										:class="{ active: watermark_settings.mode === 'Corner' }"
+										@click="_set_wm_field('mode', 'Corner')">{{ __("Corner") }}</button>
+								</div>
+							</div>
+							<template v-if="(watermark_settings.mode || 'Tiled') === 'Tiled'">
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Opacity") }}</label>
+									<input type="range" class="fu-slider" min="5" max="100"
+										:value="watermark_settings.tile_opacity || 12"
+										@input="_set_wm_field('tile_opacity', parseInt($event.target.value))" />
+									<span class="fu-slider-value">{{ watermark_settings.tile_opacity || 12 }}%</span>
+								</div>
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Tile Size") }}</label>
+									<input type="range" class="fu-slider" min="5" max="80"
+										:value="watermark_settings.tile_size || 15"
+										@input="_set_wm_field('tile_size', parseFloat($event.target.value))" />
+									<span class="fu-slider-value">{{ Math.round(watermark_settings.tile_size || 15) }}%</span>
+								</div>
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Rotation") }}</label>
+									<input type="range" class="fu-slider" min="-180" max="180"
+										:value="watermark_settings.tile_rotation != null ? watermark_settings.tile_rotation : -30"
+										@input="_set_wm_field('tile_rotation', parseInt($event.target.value))" />
+									<span class="fu-slider-value">{{ watermark_settings.tile_rotation != null ? watermark_settings.tile_rotation : -30 }}°</span>
+								</div>
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Spacing") }}</label>
+									<input type="range" class="fu-slider" min="0" max="100"
+										:value="watermark_settings.tile_spacing || 40"
+										@input="_set_wm_field('tile_spacing', parseInt($event.target.value))" />
+									<span class="fu-slider-value">{{ watermark_settings.tile_spacing || 40 }}%</span>
+								</div>
+							</template>
+							<template v-else>
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Opacity") }}</label>
+									<input type="range" class="fu-slider" min="5" max="100"
+										:value="watermark_settings.opacity || 50"
+										@input="_set_wm_field('opacity', parseInt($event.target.value))" />
+									<span class="fu-slider-value">{{ watermark_settings.opacity || 50 }}%</span>
+								</div>
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Size") }}</label>
+									<input type="range" class="fu-slider" min="5" max="100"
+										:value="watermark_settings.size || 20"
+										@input="_set_wm_field('size', parseFloat($event.target.value))" />
+									<span class="fu-slider-value">{{ Math.round(watermark_settings.size || 20) }}%</span>
+								</div>
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Position X") }}</label>
+									<input type="range" class="fu-slider" min="0" max="100"
+										:value="watermark_settings.position_x || 80"
+										@input="_set_wm_field('position_x', parseFloat($event.target.value))" />
+									<span class="fu-slider-value">{{ Math.round(watermark_settings.position_x || 80) }}%</span>
+								</div>
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Position Y") }}</label>
+									<input type="range" class="fu-slider" min="0" max="100"
+										:value="watermark_settings.position_y || 90"
+										@input="_set_wm_field('position_y', parseFloat($event.target.value))" />
+									<span class="fu-slider-value">{{ Math.round(watermark_settings.position_y || 90) }}%</span>
+								</div>
+								<div class="fu-slider-row">
+									<label class="fu-slider-label">{{ __("Rotation") }}</label>
+									<input type="range" class="fu-slider" min="-180" max="180" step="5"
+										:value="watermark_settings.corner_rotation || 0"
+										@input="_set_wm_field('corner_rotation', parseFloat($event.target.value))" />
+									<span class="fu-slider-value">{{ Math.round(watermark_settings.corner_rotation || 0) }}°</span>
+								</div>
+							</template>
+						</template>
 					</div>
 
-					<!-- COMMENTS pane -->
+					<!-- ── COMMENTS pane ── -->
 					<div v-show="active_tab === 'comments'" class="fu-tab-pane">
 						<div class="fu-tab-enable">
 							<span class="fu-tab-enable-label">{{ __("Enable Comments") }}</span>
@@ -346,12 +431,56 @@
 								</span>
 							</div>
 						</div>
-						<div class="fu-tab-note">
-							{{ __("Add, position and style text overlays in the Crop step.") }}
-						</div>
+						<template v-if="comments_enabled_default && comment_defaults">
+							<div class="fu-tab-note">{{ __("Default style for new comment boxes:") }}</div>
+							<div class="fu-tab-field">
+								<label class="fu-tab-field-label">{{ __("Font") }}</label>
+								<select class="fu-select"
+									:value="comment_defaults.font_family || 'Arial'"
+									@change="_set_comment_default('font_family', $event.target.value)">
+									<option v-for="f in ['Arial', 'Helvetica', 'Times New Roman', 'Courier New', 'Georgia', 'Verdana']" :key="f" :value="f">{{ f }}</option>
+								</select>
+							</div>
+							<div class="fu-slider-row">
+								<label class="fu-slider-label">{{ __("Size") }}</label>
+								<input type="range" class="fu-slider" min="1" max="20" step="0.5"
+									:value="comment_defaults.font_size_pct || 5"
+									@input="_set_comment_default('font_size_pct', parseFloat($event.target.value))" />
+								<span class="fu-slider-value">{{ (comment_defaults.font_size_pct || 5).toFixed(1) }}%</span>
+							</div>
+							<div class="fu-inline-field-row">
+								<label class="fu-inline-check">
+									<input type="checkbox"
+										:checked="comment_defaults.font_weight === 'Bold'"
+										@change="_set_comment_default('font_weight', $event.target.checked ? 'Bold' : 'Normal')" />
+									<span>B</span>
+								</label>
+								<label class="fu-inline-check">
+									<input type="checkbox"
+										:checked="comment_defaults.font_style === 'Italic'"
+										@change="_set_comment_default('font_style', $event.target.checked ? 'Italic' : 'Normal')" />
+									<span><em>I</em></span>
+								</label>
+								<label class="fu-inline-colour">
+									<span>{{ __("Color") }}</span>
+									<input type="color"
+										:value="comment_defaults.color || '#000000'"
+										@input="_set_comment_default('color', $event.target.value)" />
+								</label>
+							</div>
+							<div class="fu-tab-field">
+								<label class="fu-tab-field-label">{{ __("Align") }}</label>
+								<div class="fu-seg-row">
+									<button v-for="a in ['Left', 'Center', 'Right']" :key="a"
+										type="button" class="fu-seg-btn"
+										:class="{ active: (comment_defaults.align || 'Center') === a }"
+										@click="_set_comment_default('align', a)">{{ __(a) }}</button>
+								</div>
+							</div>
+						</template>
 					</div>
 
-					<!-- CANVAS pane (aspect + mode are editable here, baked later) -->
+					<!-- ── CANVAS pane ── -->
 					<div v-show="active_tab === 'canvas'" class="fu-tab-pane">
 						<div class="fu-tab-enable">
 							<span class="fu-tab-enable-label">{{ __("Enable Canvas normalization") }}</span>
@@ -365,35 +494,40 @@
 								</span>
 							</div>
 						</div>
-						<div v-if="resize_enabled_default && resize_settings" class="fu-tab-field">
-							<label class="fu-tab-field-label">{{ __("Aspect") }}</label>
-							<div class="fu-seg-row">
-								<button
-									v-for="opt in ['1:1', '4:3', '16:9', '3:2', '2:3', 'Free']"
-									:key="opt"
-									type="button"
-									class="fu-seg-btn"
-									:class="{ active: (resize_settings.resize_aspect || '1:1') === opt }"
-									@click="_set_canvas_aspect(opt)"
-								>{{ opt }}</button>
+						<template v-if="resize_enabled_default && resize_settings">
+							<div class="fu-tab-field">
+								<label class="fu-tab-field-label">{{ __("Aspect") }}</label>
+								<div class="fu-seg-row">
+									<button v-for="opt in ['1:1', '4:3', '16:9', '3:2', '2:3', 'Free']" :key="opt"
+										type="button" class="fu-seg-btn"
+										:class="{ active: (resize_settings.resize_aspect || '1:1') === opt }"
+										@click="_set_canvas_aspect(opt)">{{ opt }}</button>
+								</div>
 							</div>
-						</div>
-						<div v-if="resize_enabled_default && resize_settings" class="fu-tab-field">
-							<label class="fu-tab-field-label">{{ __("Mode") }}</label>
-							<div class="fu-seg-row">
-								<button
-									v-for="opt in ['Contain', 'Cover', 'Stretch']"
-									:key="opt"
-									type="button"
-									class="fu-seg-btn"
-									:class="{ active: (resize_settings.resize_mode || 'Contain') === opt }"
-									@click="_set_canvas_mode(opt)"
-								>{{ __(opt) }}</button>
+							<div class="fu-tab-field">
+								<label class="fu-tab-field-label">{{ __("Mode") }}</label>
+								<div class="fu-seg-row">
+									<button v-for="opt in ['Contain', 'Cover', 'Stretch']" :key="opt"
+										type="button" class="fu-seg-btn"
+										:class="{ active: (resize_settings.resize_mode || 'Contain') === opt }"
+										@click="_set_canvas_mode(opt)">{{ __(opt) }}</button>
+								</div>
 							</div>
-						</div>
-						<div v-else class="fu-tab-note">
-							{{ __("Resize, background color and file-size cap are configurable in the Crop step.") }}
-						</div>
+							<div class="fu-inline-field-row">
+								<label class="fu-inline-check">
+									<input type="checkbox"
+										:checked="resize_settings.resize_flatten_rgb !== false"
+										@change="_set_canvas_field('resize_flatten_rgb', $event.target.checked ? 1 : 0)" />
+									<span>{{ __("Solid Background") }}</span>
+								</label>
+								<label v-if="resize_settings.resize_flatten_rgb !== false" class="fu-inline-colour">
+									<span>{{ __("Color") }}</span>
+									<input type="color"
+										:value="resize_settings.resize_fill_color || '#FFFFFF'"
+										@input="_set_canvas_field('resize_fill_color', $event.target.value)" />
+								</label>
+							</div>
+						</template>
 					</div>
 				</div>
 			</template>
@@ -405,7 +539,7 @@
 			:fixed_aspect_ratio="restrictions.crop_image_aspect_ratio"
 			:show_remove_bg="show_remove_bg && !remove_bg_disabled_hint"
 			:remove_bg_checked="remove_bg_checked"
-			:remove_bg_padding_pct="remove_bg_padding_pct"
+			:remove_bg_padding_pct="step1_padding_pct"
 			:show_watermark="show_watermark"
 			:watermark_settings="watermark_settings"
 			:wm_default_enabled="wm_enabled"
@@ -561,6 +695,12 @@ export default {
 			// carry the user's default toggle intent into the cropper.
 			comments_enabled_default: !!(this.comment_defaults && this.comment_defaults.enabled),
 			resize_enabled_default: !!(this.resize_settings && this.resize_settings.resize_enabled),
+			// Auto-crop padding — initial value comes from Image Processing
+			// Settings (remove_bg_padding_pct prop). User can override on
+			// Step 1 before picking a file; the value is passed into the
+			// cropper via the :remove_bg_padding_pct prop below, so the
+			// cropper initializes to whatever Step 1 last had.
+			step1_padding_pct: this.remove_bg_padding_pct != null ? this.remove_bg_padding_pct : 2,
 			// Which right-panel tab is visible on Step 1. Reset in mounted()
 			// to the first-available feature so the pane doesn't open on a
 			// tab the consumer didn't opt into.
@@ -664,9 +804,21 @@ export default {
 		if (first) this.active_tab = first.key;
 	},
 	methods: {
-		// Canvas (Resize) aspect + mode editors for Step 1. We mutate the
-		// resize_settings object in place so the cropper picks up the
-		// latest values via its own prop watcher when the user clicks Crop.
+		// Step 1 params mutate their underlying settings objects in place
+		// so the cropper — which reads these same objects as props on
+		// mount — picks up the user's choices when they click a File
+		// Source button. All three settings objects (watermark_settings,
+		// resize_settings, comment_defaults) are passed by reference from
+		// index.js, so $set here updates the cropper's initial values.
+
+		_set_wm_field(field, value) {
+			if (!this.watermark_settings) return;
+			this.$set(this.watermark_settings, field, value);
+		},
+		_set_comment_default(field, value) {
+			if (!this.comment_defaults) return;
+			this.$set(this.comment_defaults, field, value);
+		},
 		_set_canvas_aspect(opt) {
 			if (!this.resize_settings) return;
 			this.$set(this.resize_settings, "resize_aspect", opt);
@@ -674,6 +826,10 @@ export default {
 		_set_canvas_mode(opt) {
 			if (!this.resize_settings) return;
 			this.$set(this.resize_settings, "resize_mode", opt);
+		},
+		_set_canvas_field(field, value) {
+			if (!this.resize_settings) return;
+			this.$set(this.resize_settings, field, value);
 		},
 		dragover() {
 			this.is_dragging = true;
@@ -1198,6 +1354,115 @@ export default {
 	border-color: var(--primary);
 }
 
+/* Slider row — label | slider | value, matches cropper's .wm-slider-row */
+.fu-slider-row {
+	display: grid;
+	grid-template-columns: 100px 1fr 52px;
+	align-items: center;
+	gap: 10px;
+}
+.fu-slider-label {
+	font-size: 14px;
+	font-weight: 500;
+	color: #475569;
+	margin: 0;
+}
+.fu-slider {
+	width: 100%;
+	height: 4px;
+	-webkit-appearance: none;
+	appearance: none;
+	background: #e2e8f0;
+	border-radius: 2px;
+	outline: none;
+	cursor: pointer;
+}
+.fu-slider::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background: var(--primary);
+	cursor: grab;
+	border: 2px solid white;
+	box-shadow: 0 1px 3px rgba(15, 23, 42, 0.2);
+}
+.fu-slider::-moz-range-thumb {
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background: var(--primary);
+	cursor: grab;
+	border: 2px solid white;
+}
+.fu-slider-value {
+	font-size: 13px;
+	color: #303133;
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+	font-weight: 500;
+}
+
+/* Select dropdown within a pane */
+.fu-select {
+	width: 100%;
+	padding: 7px 10px;
+	font-size: 14px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: #fff;
+	color: #303133;
+	cursor: pointer;
+}
+.fu-select:focus {
+	outline: none;
+	border-color: var(--primary);
+	box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+/* Row of inline fields: [B] [I] [Color ▣] — used in Comments + Canvas */
+.fu-inline-field-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 14px;
+	align-items: center;
+}
+.fu-inline-check {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 14px;
+	font-weight: 500;
+	color: #475569;
+	cursor: pointer;
+	margin: 0;
+}
+.fu-inline-check input[type="checkbox"] {
+	width: 18px;
+	height: 18px;
+	cursor: pointer;
+	margin: 0;
+}
+.fu-inline-colour {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 14px;
+	font-weight: 500;
+	color: #475569;
+	margin: 0;
+}
+.fu-inline-colour input[type="color"] {
+	width: 36px;
+	height: 28px;
+	padding: 2px;
+	border: 1px solid var(--border-color);
+	border-radius: 4px;
+	cursor: pointer;
+	background: transparent;
+}
+
 /* Toggle pill — same look as the cropper's compact toggle */
 .fu-toggle-pill {
 	display: inline-flex;
@@ -1306,6 +1571,12 @@ export default {
 	.fu-tab-enable-label { font-size: 15px; }
 	.fu-tab-note { font-size: 13px; }
 	.fu-recap-list li { font-size: 14px; padding: 10px 12px; }
+	.fu-slider-row {
+		grid-template-columns: 84px 1fr 44px;
+		gap: 8px;
+	}
+	.fu-slider-label { font-size: 13px; }
+	.fu-slider-value { font-size: 12px; }
 }
 
 .file-upload-area {

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -226,6 +226,9 @@
 			:wm_default_enabled="wm_enabled"
 			:show_resize="show_resize"
 			:resize_settings="resize_settings"
+			:show_comments="show_comments"
+			:comment_defaults="comment_defaults"
+			:comment_presets="comment_presets"
 			@toggle_image_cropper="toggle_image_cropper(-1)"
 			@upload_after_crop="trigger_upload = true"
 			@remove_bg_changed="remove_bg_checked = $event"
@@ -315,12 +318,25 @@ export default {
 		watermark_settings: {
 			default: null,
 		},
-		// Output Shape (new 2026-04) — aspect normalization applied at
+		// Resize (new 2026-04) — aspect normalization applied at
 		// Crop time. Mirror of Image Processing Settings' resize_* fields.
 		show_resize: {
 			default: false,
 		},
 		resize_settings: {
+			default: null,
+		},
+		// Comments (new 2026-04) — show the text-overlay list editor in
+		// the Cropper. comment_defaults = default style for new boxes;
+		// comment_presets = quick-insert library from Image Processing
+		// Settings.
+		show_comments: {
+			default: false,
+		},
+		comment_defaults: {
+			default: null,
+		},
+		comment_presets: {
 			default: null,
 		},
 	},

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -226,13 +226,17 @@
 			:wm_default_enabled="wm_enabled"
 			:show_resize="show_resize"
 			:resize_settings="resize_settings"
+			:resize_default_enabled="resize_enabled_default"
 			:show_comments="show_comments"
 			:comment_defaults="comment_defaults"
 			:comment_presets="comment_presets"
+			:comments_default_enabled="comments_enabled_default"
 			@toggle_image_cropper="toggle_image_cropper(-1)"
 			@upload_after_crop="trigger_upload = true"
 			@remove_bg_changed="remove_bg_checked = $event"
 			@wm_enabled_changed="wm_enabled = $event"
+			@comments_enabled_changed="comments_enabled_default = $event"
+			@resize_enabled_changed="resize_enabled_default = $event"
 		/>
 		<FileBrowser
 			ref="file_browser"
@@ -366,6 +370,12 @@ export default {
 			wrapper_ready: false,
 			remove_bg_checked: this.remove_bg_default && !this.remove_bg_disabled_hint,
 			wm_enabled: this.watermark_settings && this.watermark_settings.enabled ? true : false,
+			// Pre-cropper toggles for Comments + Canvas so the file-picker
+			// page exposes the same 4 features the cropper tab-panel does.
+			// Actual application happens inside ImageCropper; these just
+			// carry the user's default toggle intent into the cropper.
+			comments_enabled_default: !!(this.comment_defaults && this.comment_defaults.enabled),
+			resize_enabled_default: !!(this.resize_settings && this.resize_settings.resize_enabled),
 		};
 	},
 	created() {
@@ -789,21 +799,129 @@ export default {
 </script>
 <style>
 .file-upload-area {
-	min-height: 16rem;
+	min-height: 20rem;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	border: 1px dashed var(--dark-border-color);
-	border-radius: var(--border-radius);
+	padding: 24px;
+	border: 2px dashed var(--dark-border-color);
+	border-radius: 10px;
 	cursor: pointer;
 	background-color: var(--bg-color);
+	transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+.file-upload-area:hover {
+	border-color: var(--primary);
+	background-color: var(--control-bg, #f4f8fc);
+}
+.file-upload-area .text-center {
+	color: var(--text-muted);
+	font-size: 14px;
 }
 
+/* File picker button tiles — rounded pill-style hover, responsive grid */
+.file-upload-area .mt-2.text-center {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 12px;
+	margin-top: 18px !important;
+}
 .btn-file-upload {
 	background-color: transparent;
-	border: none;
+	border: 1px solid transparent;
+	border-radius: 12px;
 	box-shadow: none;
+	padding: 14px 18px;
 	font-size: var(--text-xs);
+	min-width: 96px;
+	display: inline-flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+	transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+.btn-file-upload:hover {
+	transform: translateY(-1px);
+	background: #fff;
+	border-color: var(--border-color);
+	box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+}
+.btn-file-upload:active {
+	transform: translateY(0);
+}
+.btn-file-upload svg {
+	display: block;
+}
+.btn-file-upload .mt-1 {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--text-color);
+	margin-top: 2px !important;
+}
+
+/* Post-crop file preview list — rounded rows, breathable spacing,
+   responsive for narrow viewports. Overrides base FilePreview.vue
+   styles so the list lines up with the modal's new sizing. */
+.file-uploader .file-preview-container {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-bottom: 14px;
+}
+.file-uploader .file-preview-container .file-preview {
+	border: 1px solid var(--border-color);
+	border-radius: 10px;
+	background: #fff;
+	padding: 12px 14px;
+	transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.file-uploader .file-preview-container .file-preview + .file-preview {
+	border-top-color: var(--border-color);
+}
+.file-uploader .file-preview-container .file-preview:hover {
+	background-color: var(--bg-color);
+	border-color: var(--dark-border-color);
+	box-shadow: 0 1px 4px rgba(15, 23, 42, 0.06);
+}
+.file-uploader .file-preview .file-icon {
+	width: 3rem;
+	height: 3rem;
+	border-radius: 8px;
+}
+.file-uploader .file-preview .file-name {
+	font-size: 13px;
+	font-weight: 600;
+}
+.file-uploader .file-preview .file-size {
+	font-size: 12px;
+}
+.file-uploader .file-preview .config-area {
+	margin-top: 4px;
+}
+
+/* Below-list action row (Upload button + help text) — align vertically
+   on mobile so the button never ends up squeezed under a long hint. */
+.file-uploader .flex.align-center {
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+	.file-upload-area {
+		min-height: 14rem;
+		padding: 16px;
+	}
+	.file-upload-area .mt-2.text-center {
+		gap: 8px;
+	}
+	.btn-file-upload {
+		min-width: 80px;
+		padding: 10px 12px;
+	}
+	.file-uploader .file-preview-container .file-preview {
+		padding: 10px;
+	}
 }
 
 .footer-toggle {
@@ -1023,6 +1141,20 @@ export default {
 	flex: 1 1 auto;
 	overflow-y: auto;
 }
+/* Footer region — standard-actions holds the primary Upload button,
+   custom-actions holds the feature toggles (Watermark / Remove BG
+   pills). Space them properly so they don't collide, and wrap on
+   narrow viewports. */
+.file-uploader-dialog .modal-footer {
+	gap: 10px;
+	flex-wrap: wrap;
+}
+.file-uploader-dialog .modal-footer .custom-btns {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
 @media (max-width: 768px) {
 	.file-uploader-dialog .modal-dialog {
 		max-width: 100vw;
@@ -1033,6 +1165,22 @@ export default {
 		min-height: 100vh;
 		max-height: 100vh;
 		border-radius: 0;
+	}
+	.file-uploader-dialog .modal-footer {
+		flex-direction: column;
+		align-items: stretch;
+	}
+	.file-uploader-dialog .modal-footer .custom-btns {
+		justify-content: center;
+		order: -1; /* Toggles above primary action on mobile */
+	}
+	.file-uploader-dialog .modal-footer .standard-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 6px;
+	}
+	.footer-toggle {
+		margin-right: 0;
 	}
 }
 </style>

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -273,270 +273,293 @@
 				</div>
 			</template>
 
-			<!-- Step 1 (no files yet): interactive 4-tab panel — full
-			     editable params, mirroring the cropper's right panel so
-			     users can set their defaults before picking a file. -->
+			<!-- Step 1 (no files yet): interactive 4-tab panel — reuses
+			     the cropper's existing .cropper-feature-tabs / .cropper-tab-*
+			     / .wm-slider-row / .segmented-tabs / .wm-panel-actions classes
+			     so Step 1 and Step 2 are visually identical, driven by ONE
+			     stylesheet. -->
 			<template v-else>
-				<div class="fu-feature-tabs" role="tablist">
+				<div class="cropper-feature-tabs" role="tablist">
 					<button
 						v-for="tab in available_tabs"
 						:key="tab.key"
 						type="button"
-						class="fu-feature-tab"
+						class="cropper-feature-tab"
 						:class="{ active: active_tab === tab.key }"
 						role="tab"
 						:aria-selected="active_tab === tab.key"
 						@click.stop.prevent="_switch_tab(tab.key)"
 					>
-						<span class="fu-feature-tab-label">{{ tab.label }}</span>
-						<span class="fu-feature-tab-state" :class="tab.on ? 'on' : 'off'">
-							<span class="fu-feature-tab-dot"></span>
+						<span class="cropper-feature-tab-label">{{ tab.label }}</span>
+						<span class="cropper-feature-tab-state" :class="tab.on ? 'on' : 'off'">
+							<span class="cropper-feature-tab-dot"></span>
 							{{ tab.on ? __("on") : __("off") }}
 						</span>
 					</button>
 				</div>
 
-				<div class="fu-tab-body">
+				<div class="cropper-tab-body">
 					<!-- ── REMOVE BG pane ── -->
-					<div v-show="active_tab === 'remove_bg'" class="fu-tab-pane">
-						<div class="fu-tab-enable">
-							<span class="fu-tab-enable-label">{{ __("Enable Remove Background") }}</span>
+					<div v-show="active_tab === 'remove_bg'" class="cropper-tab-pane">
+						<div class="cropper-tab-enable">
+							<span class="cropper-tab-enable-label">{{ __("Enable Remove Background") }}</span>
 							<div
-								class="fu-toggle-pill"
+								class="toggle-pill toggle-pill-compact"
 								:class="{ active: remove_bg_checked, 'is-disabled': !!remove_bg_disabled_hint }"
 								@click="!remove_bg_disabled_hint && (remove_bg_checked = !remove_bg_checked)"
 							>
-								<span class="fu-toggle-track" :class="{ on: remove_bg_checked && !remove_bg_disabled_hint }">
-									<span class="fu-toggle-thumb"></span>
+								<span class="toggle-pill-switch">
+									<span class="toggle-pill-track" :class="{ on: remove_bg_checked && !remove_bg_disabled_hint }">
+										<span class="toggle-pill-thumb"></span>
+									</span>
 								</span>
 							</div>
 						</div>
-						<div v-if="remove_bg_disabled_hint" class="fu-tab-note">
+						<div v-if="remove_bg_disabled_hint" class="adjustments-row adjustments-warn">
 							{{ remove_bg_disabled_hint }}
 							<a v-if="remove_bg_disabled_link" :href="remove_bg_disabled_link">{{ __("Configure") }}</a>
 						</div>
-						<template v-else>
-							<div class="fu-slider-row">
-								<label class="fu-slider-label">{{ __("Auto-crop padding") }}</label>
-								<input type="range" class="fu-slider" min="-20" max="40" step="1"
+						<div v-else-if="remove_bg_checked" class="adjustments-row">
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Auto-crop padding") }}</label>
+								<input type="range" class="wm-slider" min="-20" max="40" step="1"
 									:value="step1_padding_pct"
 									@input="step1_padding_pct = parseInt($event.target.value)" />
-								<span class="fu-slider-value">{{ step1_padding_pct }}%</span>
+								<span class="wm-slider-value">{{ step1_padding_pct }}%</span>
 							</div>
-						</template>
+							<div class="wm-panel-actions">
+								<button class="btn btn-xs btn-default" @click="_reset_bg_default">{{ __("Reset") }}</button>
+								<button class="btn btn-xs btn-primary-light" @click="_save_bg_default">{{ __("Save as Default") }}</button>
+							</div>
+						</div>
 					</div>
 
 					<!-- ── WATERMARK pane ── -->
-					<div v-show="active_tab === 'watermark'" class="fu-tab-pane">
-						<div class="fu-tab-enable">
-							<span class="fu-tab-enable-label">{{ __("Enable Watermark") }}</span>
+					<div v-show="active_tab === 'watermark'" class="cropper-tab-pane">
+						<div class="cropper-tab-enable">
+							<span class="cropper-tab-enable-label">{{ __("Enable Watermark") }}</span>
 							<div
-								class="fu-toggle-pill"
+								class="toggle-pill toggle-pill-compact"
 								:class="{ active: wm_enabled, 'is-disabled': !local_watermark_settings || !local_watermark_settings.watermark_image }"
 								@click="(local_watermark_settings && local_watermark_settings.watermark_image) && (wm_enabled = !wm_enabled)"
 							>
-								<span class="fu-toggle-track" :class="{ on: wm_enabled }">
-									<span class="fu-toggle-thumb"></span>
+								<span class="toggle-pill-switch">
+									<span class="toggle-pill-track" :class="{ on: wm_enabled }">
+										<span class="toggle-pill-thumb"></span>
+									</span>
 								</span>
 							</div>
 						</div>
-						<div v-if="!local_watermark_settings || !local_watermark_settings.watermark_image" class="fu-tab-note">
+						<div v-if="!local_watermark_settings || !local_watermark_settings.watermark_image" class="adjustments-row adjustments-warn">
 							{{ __("No watermark image uploaded.") }}
 							<a href="/app/watermark-settings">{{ __("Configure") }}</a>
 						</div>
-						<template v-else-if="wm_enabled">
-							<div class="fu-tab-field">
-								<label class="fu-tab-field-label">{{ __("Mode") }}</label>
-								<div class="fu-seg-row">
-									<button type="button" class="fu-seg-btn"
-										:class="{ active: (local_watermark_settings.mode || 'Tiled') === 'Tiled' }"
-										@click="_set_wm_field('mode', 'Tiled')">{{ __("Tiled") }}</button>
-									<button type="button" class="fu-seg-btn"
-										:class="{ active: local_watermark_settings.mode === 'Corner' }"
-										@click="_set_wm_field('mode', 'Corner')">{{ __("Corner") }}</button>
-								</div>
+						<div v-else-if="wm_enabled" class="adjustments-row adjustments-row-wm">
+							<div class="segmented-tabs" role="tablist">
+								<button type="button" class="segmented-tab"
+									:class="{ active: (local_watermark_settings.mode || 'Tiled') === 'Tiled' }"
+									@click="_set_wm_field('mode', 'Tiled')">
+									<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+									{{ __("Tiled") }}
+								</button>
+								<button type="button" class="segmented-tab"
+									:class="{ active: local_watermark_settings.mode === 'Corner' }"
+									@click="_set_wm_field('mode', 'Corner')">
+									<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L12 12"/><rect x="2" y="14" width="10" height="8" rx="1"/></svg>
+									{{ __("Corner") }}
+								</button>
 							</div>
 							<template v-if="(local_watermark_settings.mode || 'Tiled') === 'Tiled'">
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Opacity") }}</label>
-									<input type="range" class="fu-slider" min="5" max="100"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Opacity") }}</label>
+									<input type="range" class="wm-slider" min="5" max="100"
 										:value="local_watermark_settings.tile_opacity || 12"
 										@input="_set_wm_field('tile_opacity', parseInt($event.target.value))" />
-									<span class="fu-slider-value">{{ local_watermark_settings.tile_opacity || 12 }}%</span>
+									<span class="wm-slider-value">{{ local_watermark_settings.tile_opacity || 12 }}%</span>
 								</div>
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Tile Size") }}</label>
-									<input type="range" class="fu-slider" min="5" max="80"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Tile Size") }}</label>
+									<input type="range" class="wm-slider" min="5" max="80"
 										:value="local_watermark_settings.tile_size || 15"
 										@input="_set_wm_field('tile_size', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.tile_size || 15) }}%</span>
+									<span class="wm-slider-value">{{ Math.round(local_watermark_settings.tile_size || 15) }}%</span>
 								</div>
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Rotation") }}</label>
-									<input type="range" class="fu-slider" min="-180" max="180"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Rotation") }}</label>
+									<input type="range" class="wm-slider" min="-180" max="180"
 										:value="local_watermark_settings.tile_rotation != null ? local_watermark_settings.tile_rotation : -30"
 										@input="_set_wm_field('tile_rotation', parseInt($event.target.value))" />
-									<span class="fu-slider-value">{{ local_watermark_settings.tile_rotation != null ? local_watermark_settings.tile_rotation : -30 }}°</span>
+									<span class="wm-slider-value">{{ local_watermark_settings.tile_rotation != null ? local_watermark_settings.tile_rotation : -30 }}°</span>
 								</div>
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Spacing") }}</label>
-									<input type="range" class="fu-slider" min="0" max="100"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Spacing") }}</label>
+									<input type="range" class="wm-slider" min="0" max="100"
 										:value="local_watermark_settings.tile_spacing || 40"
 										@input="_set_wm_field('tile_spacing', parseInt($event.target.value))" />
-									<span class="fu-slider-value">{{ local_watermark_settings.tile_spacing || 40 }}%</span>
+									<span class="wm-slider-value">{{ local_watermark_settings.tile_spacing || 40 }}%</span>
 								</div>
 							</template>
 							<template v-else>
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Opacity") }}</label>
-									<input type="range" class="fu-slider" min="5" max="100"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Opacity") }}</label>
+									<input type="range" class="wm-slider" min="5" max="100"
 										:value="local_watermark_settings.opacity || 50"
 										@input="_set_wm_field('opacity', parseInt($event.target.value))" />
-									<span class="fu-slider-value">{{ local_watermark_settings.opacity || 50 }}%</span>
+									<span class="wm-slider-value">{{ local_watermark_settings.opacity || 50 }}%</span>
 								</div>
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Size") }}</label>
-									<input type="range" class="fu-slider" min="5" max="100"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Size") }}</label>
+									<input type="range" class="wm-slider" min="5" max="100"
 										:value="local_watermark_settings.size || 20"
 										@input="_set_wm_field('size', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.size || 20) }}%</span>
+									<span class="wm-slider-value">{{ Math.round(local_watermark_settings.size || 20) }}%</span>
 								</div>
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Position X") }}</label>
-									<input type="range" class="fu-slider" min="0" max="100"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Position X") }}</label>
+									<input type="range" class="wm-slider" min="0" max="100"
 										:value="local_watermark_settings.position_x || 80"
 										@input="_set_wm_field('position_x', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.position_x || 80) }}%</span>
+									<span class="wm-slider-value">{{ Math.round(local_watermark_settings.position_x || 80) }}%</span>
 								</div>
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Position Y") }}</label>
-									<input type="range" class="fu-slider" min="0" max="100"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Position Y") }}</label>
+									<input type="range" class="wm-slider" min="0" max="100"
 										:value="local_watermark_settings.position_y || 90"
 										@input="_set_wm_field('position_y', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.position_y || 90) }}%</span>
+									<span class="wm-slider-value">{{ Math.round(local_watermark_settings.position_y || 90) }}%</span>
 								</div>
-								<div class="fu-slider-row">
-									<label class="fu-slider-label">{{ __("Rotation") }}</label>
-									<input type="range" class="fu-slider" min="-180" max="180" step="5"
+								<div class="wm-slider-row">
+									<label class="wm-slider-label">{{ __("Rotation") }}</label>
+									<input type="range" class="wm-slider" min="-180" max="180" step="5"
 										:value="local_watermark_settings.corner_rotation || 0"
 										@input="_set_wm_field('corner_rotation', parseFloat($event.target.value))" />
-									<span class="fu-slider-value">{{ Math.round(local_watermark_settings.corner_rotation || 0) }}°</span>
+									<span class="wm-slider-value">{{ Math.round(local_watermark_settings.corner_rotation || 0) }}°</span>
 								</div>
 							</template>
-						</template>
+							<div class="wm-panel-actions">
+								<button class="btn btn-xs btn-default" @click="_reset_wm_default">{{ __("Reset") }}</button>
+								<button class="btn btn-xs btn-primary-light" @click="_save_wm_default">{{ __("Save as Default") }}</button>
+							</div>
+						</div>
 					</div>
 
 					<!-- ── COMMENTS pane ── -->
-					<div v-show="active_tab === 'comments'" class="fu-tab-pane">
-						<div class="fu-tab-enable">
-							<span class="fu-tab-enable-label">{{ __("Enable Comments") }}</span>
+					<div v-show="active_tab === 'comments'" class="cropper-tab-pane">
+						<div class="cropper-tab-enable">
+							<span class="cropper-tab-enable-label">{{ __("Enable Comments") }}</span>
 							<div
-								class="fu-toggle-pill"
+								class="toggle-pill toggle-pill-compact"
 								:class="{ active: comments_enabled_default }"
 								@click="comments_enabled_default = !comments_enabled_default"
 							>
-								<span class="fu-toggle-track" :class="{ on: comments_enabled_default }">
-									<span class="fu-toggle-thumb"></span>
+								<span class="toggle-pill-switch">
+									<span class="toggle-pill-track" :class="{ on: comments_enabled_default }">
+										<span class="toggle-pill-thumb"></span>
+									</span>
 								</span>
 							</div>
 						</div>
-						<template v-if="comments_enabled_default && local_comment_defaults">
-							<div class="fu-tab-note">{{ __("Default style for new comment boxes:") }}</div>
-							<div class="fu-tab-field">
-								<label class="fu-tab-field-label">{{ __("Font") }}</label>
-								<select class="fu-select"
+						<div v-if="comments_enabled_default && local_comment_defaults" class="adjustments-row">
+							<label class="adjustments-field-label">{{ __("Default style for new comment boxes") }}</label>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Font") }}</label>
+								<select class="wm-select-inline"
 									:value="local_comment_defaults.font_family || 'Arial'"
 									@change="_set_comment_default('font_family', $event.target.value)">
 									<option v-for="f in ['Arial', 'Helvetica', 'Times New Roman', 'Courier New', 'Georgia', 'Verdana']" :key="f" :value="f">{{ f }}</option>
 								</select>
 							</div>
-							<div class="fu-slider-row">
-								<label class="fu-slider-label">{{ __("Size") }}</label>
-								<input type="range" class="fu-slider" min="1" max="20" step="0.5"
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Size") }}</label>
+								<input type="range" class="wm-slider" min="1" max="20" step="0.5"
 									:value="local_comment_defaults.font_size_pct || 5"
 									@input="_set_comment_default('font_size_pct', parseFloat($event.target.value))" />
-								<span class="fu-slider-value">{{ (local_comment_defaults.font_size_pct || 5).toFixed(1) }}%</span>
+								<span class="wm-slider-value">{{ (local_comment_defaults.font_size_pct || 5).toFixed(1) }}%</span>
 							</div>
-							<div class="fu-inline-field-row">
-								<label class="fu-inline-check">
+							<div class="wm-inline-row">
+								<label class="wm-inline-check">
 									<input type="checkbox"
 										:checked="local_comment_defaults.font_weight === 'Bold'"
 										@change="_set_comment_default('font_weight', $event.target.checked ? 'Bold' : 'Normal')" />
-									<span>B</span>
+									<span><strong>B</strong></span>
 								</label>
-								<label class="fu-inline-check">
+								<label class="wm-inline-check">
 									<input type="checkbox"
 										:checked="local_comment_defaults.font_style === 'Italic'"
 										@change="_set_comment_default('font_style', $event.target.checked ? 'Italic' : 'Normal')" />
 									<span><em>I</em></span>
 								</label>
-								<label class="fu-inline-colour">
+								<label class="wm-inline-colour">
 									<span>{{ __("Color") }}</span>
 									<input type="color"
 										:value="local_comment_defaults.color || '#000000'"
 										@input="_set_comment_default('color', $event.target.value)" />
 								</label>
 							</div>
-							<div class="fu-tab-field">
-								<label class="fu-tab-field-label">{{ __("Align") }}</label>
-								<div class="fu-seg-row">
-									<button v-for="a in ['Left', 'Center', 'Right']" :key="a"
-										type="button" class="fu-seg-btn"
-										:class="{ active: (local_comment_defaults.align || 'Center') === a }"
-										@click="_set_comment_default('align', a)">{{ __(a) }}</button>
-								</div>
+							<label class="adjustments-field-label" style="margin-top:8px">{{ __("Align") }}</label>
+							<div class="segmented-tabs" role="tablist">
+								<button v-for="a in ['Left', 'Center', 'Right']" :key="a"
+									type="button" class="segmented-tab"
+									:class="{ active: (local_comment_defaults.align || 'Center') === a }"
+									@click="_set_comment_default('align', a)">{{ __(a) }}</button>
 							</div>
-						</template>
+							<div class="wm-panel-actions">
+								<button class="btn btn-xs btn-default" @click="_reset_comment_default">{{ __("Reset") }}</button>
+								<button class="btn btn-xs btn-primary-light" @click="_save_comment_default">{{ __("Save as Default") }}</button>
+							</div>
+						</div>
 					</div>
 
 					<!-- ── CANVAS pane ── -->
-					<div v-show="active_tab === 'canvas'" class="fu-tab-pane">
-						<div class="fu-tab-enable">
-							<span class="fu-tab-enable-label">{{ __("Enable Canvas normalization") }}</span>
+					<div v-show="active_tab === 'canvas'" class="cropper-tab-pane">
+						<div class="cropper-tab-enable">
+							<span class="cropper-tab-enable-label">{{ __("Enable Canvas normalization") }}</span>
 							<div
-								class="fu-toggle-pill"
+								class="toggle-pill toggle-pill-compact"
 								:class="{ active: resize_enabled_default }"
 								@click="resize_enabled_default = !resize_enabled_default"
 							>
-								<span class="fu-toggle-track" :class="{ on: resize_enabled_default }">
-									<span class="fu-toggle-thumb"></span>
+								<span class="toggle-pill-switch">
+									<span class="toggle-pill-track" :class="{ on: resize_enabled_default }">
+										<span class="toggle-pill-thumb"></span>
+									</span>
 								</span>
 							</div>
 						</div>
-						<template v-if="resize_enabled_default && local_resize_settings">
-							<div class="fu-tab-field">
-								<label class="fu-tab-field-label">{{ __("Aspect") }}</label>
-								<div class="fu-seg-row">
-									<button v-for="opt in ['1:1', '4:3', '16:9', '3:2', '2:3', 'Free']" :key="opt"
-										type="button" class="fu-seg-btn"
-										:class="{ active: (local_resize_settings.resize_aspect || '1:1') === opt }"
-										@click="_set_canvas_aspect(opt)">{{ opt }}</button>
-								</div>
+						<div v-if="resize_enabled_default && local_resize_settings" class="adjustments-row">
+							<label class="adjustments-field-label">{{ __("Aspect") }}</label>
+							<div class="segmented-tabs" role="tablist">
+								<button v-for="opt in ['1:1', '4:3', '16:9', '3:2', '2:3', 'Free']" :key="opt"
+									type="button" class="segmented-tab"
+									:class="{ active: (local_resize_settings.resize_aspect || '1:1') === opt }"
+									@click="_set_canvas_aspect(opt)">{{ opt }}</button>
 							</div>
-							<div class="fu-tab-field">
-								<label class="fu-tab-field-label">{{ __("Mode") }}</label>
-								<div class="fu-seg-row">
-									<button v-for="opt in ['Contain', 'Cover', 'Stretch']" :key="opt"
-										type="button" class="fu-seg-btn"
-										:class="{ active: (local_resize_settings.resize_mode || 'Contain') === opt }"
-										@click="_set_canvas_mode(opt)">{{ __(opt) }}</button>
-								</div>
+							<label class="adjustments-field-label" style="margin-top:12px">{{ __("Mode") }}</label>
+							<div class="segmented-tabs" role="tablist">
+								<button v-for="opt in ['Contain', 'Cover', 'Stretch']" :key="opt"
+									type="button" class="segmented-tab"
+									:class="{ active: (local_resize_settings.resize_mode || 'Contain') === opt }"
+									@click="_set_canvas_mode(opt)">{{ __(opt) }}</button>
 							</div>
-							<div class="fu-inline-field-row">
-								<label class="fu-inline-check">
+							<div class="wm-inline-row">
+								<label class="wm-inline-check">
 									<input type="checkbox"
 										:checked="local_resize_settings.resize_flatten_rgb !== false"
 										@change="_set_canvas_field('resize_flatten_rgb', $event.target.checked ? 1 : 0)" />
 									<span>{{ __("Solid Background") }}</span>
 								</label>
-								<label v-if="local_resize_settings.resize_flatten_rgb !== false" class="fu-inline-colour">
+								<label v-if="local_resize_settings.resize_flatten_rgb !== false" class="wm-inline-colour">
 									<span>{{ __("Color") }}</span>
 									<input type="color"
 										:value="local_resize_settings.resize_fill_color || '#FFFFFF'"
 										@input="_set_canvas_field('resize_fill_color', $event.target.value)" />
 								</label>
 							</div>
-						</template>
+							<div class="wm-panel-actions">
+								<button class="btn btn-xs btn-default" @click="_reset_canvas_default">{{ __("Reset") }}</button>
+								<button class="btn btn-xs btn-primary-light" @click="_save_canvas_default">{{ __("Save as Default") }}</button>
+							</div>
+						</div>
 					</div>
 				</div>
 			</template>
@@ -906,6 +929,128 @@ export default {
 		_set_canvas_field(field, value) {
 			if (!this.local_resize_settings) return;
 			this.$set(this.local_resize_settings, field, value);
+		},
+
+		// ── Reset / Save-as-default buttons per tab ─────────────────
+		// Reset reverts the local editable copy to the prop value the
+		// uploader was constructed with (what Settings had at dialog
+		// open). Save persists the current local values back to the
+		// Settings DocType via frappe.client.set_value so future
+		// uploads inherit them.
+
+		_reset_bg_default() {
+			this.step1_padding_pct = this.remove_bg_padding_pct != null
+				? this.remove_bg_padding_pct : 2;
+			frappe.show_alert({ message: __("Reset to saved defaults"), indicator: "blue" });
+		},
+		_save_bg_default() {
+			frappe.call({
+				method: "frappe.client.set_value",
+				args: {
+					doctype: "Image Processing Settings",
+					name: "Image Processing Settings",
+					fieldname: { remove_bg_padding_pct: this.step1_padding_pct },
+				},
+			}).then(() => {
+				frappe.show_alert({ message: __("Auto-crop padding saved as default"), indicator: "green" });
+			}).catch(() => {
+				frappe.show_alert({ message: __("Failed to save default"), indicator: "red" });
+			});
+		},
+
+		_reset_wm_default() {
+			if (!this.watermark_settings) return;
+			this.local_watermark_settings = JSON.parse(JSON.stringify(this.watermark_settings));
+			frappe.show_alert({ message: __("Reset to saved defaults"), indicator: "blue" });
+		},
+		_save_wm_default() {
+			const s = this.local_watermark_settings;
+			if (!s) return;
+			frappe.call({
+				method: "frappe.client.set_value",
+				args: {
+					doctype: "Watermark Settings",
+					name: "Watermark Settings",
+					fieldname: {
+						mode: s.mode || "Tiled",
+						position_x: s.position_x != null ? s.position_x : 80,
+						position_y: s.position_y != null ? s.position_y : 90,
+						corner_rotation: s.corner_rotation != null ? s.corner_rotation : 0,
+						size: s.size != null ? s.size : 20,
+						opacity: s.opacity != null ? s.opacity : 50,
+						tile_size: s.tile_size != null ? s.tile_size : 15,
+						tile_opacity: s.tile_opacity != null ? s.tile_opacity : 12,
+						tile_rotation: s.tile_rotation != null ? s.tile_rotation : -30,
+						tile_spacing: s.tile_spacing != null ? s.tile_spacing : 40,
+					},
+				},
+			}).then(() => {
+				// Refresh the shared cache so subsequent upload dialogs pick up
+				// the new defaults without a page reload.
+				if (frappe._watermark_settings_cache) {
+					Object.assign(frappe._watermark_settings_cache, s);
+				}
+				frappe.show_alert({ message: __("Watermark defaults saved"), indicator: "green" });
+			}).catch(() => {
+				frappe.show_alert({ message: __("Failed to save defaults"), indicator: "red" });
+			});
+		},
+
+		_reset_comment_default() {
+			if (!this.comment_defaults) return;
+			this.local_comment_defaults = JSON.parse(JSON.stringify(this.comment_defaults));
+			frappe.show_alert({ message: __("Reset to saved defaults"), indicator: "blue" });
+		},
+		_save_comment_default() {
+			const c = this.local_comment_defaults;
+			if (!c) return;
+			frappe.call({
+				method: "frappe.client.set_value",
+				args: {
+					doctype: "Image Processing Settings",
+					name: "Image Processing Settings",
+					fieldname: {
+						default_comment_font_family: c.font_family || "Arial",
+						default_comment_font_size_pct: c.font_size_pct || 5,
+						default_comment_font_weight: c.font_weight || "Normal",
+						default_comment_font_style: c.font_style || "Normal",
+						default_comment_color: c.color || "#000000",
+						default_comment_align: c.align || "Center",
+					},
+				},
+			}).then(() => {
+				frappe.show_alert({ message: __("Comment defaults saved"), indicator: "green" });
+			}).catch(() => {
+				frappe.show_alert({ message: __("Failed to save defaults"), indicator: "red" });
+			});
+		},
+
+		_reset_canvas_default() {
+			if (!this.resize_settings) return;
+			this.local_resize_settings = JSON.parse(JSON.stringify(this.resize_settings));
+			frappe.show_alert({ message: __("Reset to saved defaults"), indicator: "blue" });
+		},
+		_save_canvas_default() {
+			const r = this.local_resize_settings;
+			if (!r) return;
+			frappe.call({
+				method: "frappe.client.set_value",
+				args: {
+					doctype: "Image Processing Settings",
+					name: "Image Processing Settings",
+					fieldname: {
+						resize_enabled: this.resize_enabled_default ? 1 : 0,
+						resize_aspect: r.resize_aspect || "1:1",
+						resize_mode: r.resize_mode || "Contain",
+						resize_fill_color: r.resize_fill_color || "#FFFFFF",
+						resize_flatten_rgb: r.resize_flatten_rgb !== false ? 1 : 0,
+					},
+				},
+			}).then(() => {
+				frappe.show_alert({ message: __("Canvas defaults saved"), indicator: "green" });
+			}).catch(() => {
+				frappe.show_alert({ message: __("Failed to save defaults"), indicator: "red" });
+			});
 		},
 		dragover() {
 			this.is_dragging = true;
@@ -1308,248 +1453,113 @@ export default {
 	min-height: 360px;
 }
 
-/* Tab header strip ─ matches the cropper's .cropper-feature-tabs
-   visual style so Step 1 and Step 2 look like the same control. */
-.fu-feature-tabs {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+/* ── Shared panel styles ──────────────────────────────────────────
+   Identical selectors + values to the cropper's scoped styles
+   (ImageCropper.vue). Because those are `scoped`, they only apply
+   inside the cropper; the uploader's Step 1 panel needs its own
+   copy so it renders identically without cross-component leaks.
+-------------------------------------------------------------------- */
+
+/* Tab header strip */
+.file-uploader .cropper-feature-tabs {
+	display: flex;
 	gap: 6px;
-	background: #f1f5f9;
-	border-radius: 10px;
-	padding: 6px;
+	margin-bottom: 10px;
 }
-.fu-feature-tab {
+.file-uploader .cropper-feature-tab {
+	flex: 1;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 5px;
-	padding: 12px 8px;
-	background: transparent;
-	border: none;
+	gap: 4px;
+	padding: 10px 6px;
+	background: #fff;
+	border: 1px solid var(--border-color);
 	border-radius: 8px;
 	cursor: pointer;
-	color: #64748b;
-	transition: background 0.15s ease, color 0.15s ease;
+	color: #303133;
+	transition: all 0.15s ease;
 }
-.fu-feature-tab:hover { background: rgba(255, 255, 255, 0.55); }
-.fu-feature-tab.active {
-	background: #fff;
-	color: var(--primary);
-	box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+.file-uploader .cropper-feature-tab:hover {
+	border-color: var(--primary);
 }
-.fu-feature-tab-label {
+.file-uploader .cropper-feature-tab.active {
+	border: 2px solid var(--primary);
+	background: #ecf5ff;
+}
+.file-uploader .cropper-feature-tab-label {
 	font-weight: 600;
 	font-size: 15px;
+	color: #303133;
 	line-height: 1.2;
 }
-.fu-feature-tab-state {
+.file-uploader .cropper-feature-tab.active .cropper-feature-tab-label {
+	color: var(--primary);
+}
+.file-uploader .cropper-feature-tab-state {
 	display: inline-flex;
 	align-items: center;
-	gap: 4px;
+	gap: 5px;
 	font-size: 13px;
-	font-weight: 500;
+	font-weight: 600;
 	text-transform: uppercase;
-	letter-spacing: 0.02em;
 }
-.fu-feature-tab-state.on { color: #10b981; }
-.fu-feature-tab-state.off { color: #94a3b8; }
-.fu-feature-tab-dot {
+.file-uploader .cropper-feature-tab-state.on { color: #22c55e; }
+.file-uploader .cropper-feature-tab-state.off { color: #94a3b8; }
+.file-uploader .cropper-feature-tab-dot {
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;
 	background: currentColor;
 }
 
-.fu-tab-body { flex: 1 1 auto; }
-.fu-tab-pane {
+/* Tab body */
+.file-uploader .cropper-tab-body {
+	flex: 1;
+	padding: 14px;
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	background: #fff;
+	overflow-y: auto;
+	min-height: 0;
+}
+.file-uploader .cropper-tab-pane {
 	display: flex;
 	flex-direction: column;
 	gap: 14px;
 }
-.fu-tab-enable {
+
+/* "Enable X" row at top of each pane */
+.file-uploader .cropper-tab-enable {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding: 14px 16px;
+	padding: 12px 14px;
 	border: 1px solid var(--border-color);
-	border-radius: 8px;
+	border-radius: 6px;
 	background: #fafbfc;
 }
-.fu-tab-enable-label {
+.file-uploader .cropper-tab-enable-label {
 	font-size: 16px;
 	font-weight: 600;
 	color: #303133;
 }
-.fu-tab-note {
-	font-size: 14px;
-	color: var(--text-muted);
-	line-height: 1.55;
-	padding: 12px 14px;
-	background: #f8fafc;
-	border-radius: 8px;
-}
-.fu-tab-note a {
-	color: var(--primary);
-	text-decoration: underline;
-	margin-left: 4px;
-}
-.fu-tab-field {
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
-}
-.fu-tab-field-label {
-	font-size: 14px;
-	font-weight: 600;
-	color: #475569;
-	text-transform: uppercase;
-	letter-spacing: 0.03em;
-	margin: 0;
-}
-.fu-seg-row {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-}
-.fu-seg-btn {
-	padding: 7px 14px;
-	font-size: 14px;
-	font-weight: 500;
-	color: #475569;
-	background: #fff;
-	border: 1px solid var(--border-color);
-	border-radius: 6px;
-	cursor: pointer;
-	transition: all 0.15s ease;
-}
-.fu-seg-btn:hover { border-color: var(--primary); }
-.fu-seg-btn.active {
-	background: var(--primary);
-	color: #fff;
-	border-color: var(--primary);
-}
 
-/* Slider row — label | slider | value, matches cropper's .wm-slider-row */
-.fu-slider-row {
-	display: grid;
-	grid-template-columns: 100px 1fr 52px;
-	align-items: center;
-	gap: 10px;
-}
-.fu-slider-label {
-	font-size: 14px;
-	font-weight: 500;
-	color: #475569;
-	margin: 0;
-}
-.fu-slider {
-	width: 100%;
-	height: 4px;
-	-webkit-appearance: none;
-	appearance: none;
-	background: #e2e8f0;
-	border-radius: 2px;
-	outline: none;
-	cursor: pointer;
-}
-.fu-slider::-webkit-slider-thumb {
-	-webkit-appearance: none;
-	appearance: none;
-	width: 16px;
-	height: 16px;
-	border-radius: 50%;
-	background: var(--primary);
-	cursor: grab;
-	border: 2px solid white;
-	box-shadow: 0 1px 3px rgba(15, 23, 42, 0.2);
-}
-.fu-slider::-moz-range-thumb {
-	width: 16px;
-	height: 16px;
-	border-radius: 50%;
-	background: var(--primary);
-	cursor: grab;
-	border: 2px solid white;
-}
-.fu-slider-value {
-	font-size: 13px;
-	color: #303133;
-	text-align: right;
-	font-variant-numeric: tabular-nums;
-	font-weight: 500;
-}
-
-/* Select dropdown within a pane */
-.fu-select {
-	width: 100%;
-	padding: 7px 10px;
-	font-size: 14px;
-	border: 1px solid var(--border-color);
-	border-radius: 6px;
-	background: #fff;
-	color: #303133;
-	cursor: pointer;
-}
-.fu-select:focus {
-	outline: none;
-	border-color: var(--primary);
-	box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
-}
-
-/* Row of inline fields: [B] [I] [Color ▣] — used in Comments + Canvas */
-.fu-inline-field-row {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 14px;
-	align-items: center;
-}
-.fu-inline-check {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 14px;
-	font-weight: 500;
-	color: #475569;
-	cursor: pointer;
-	margin: 0;
-}
-.fu-inline-check input[type="checkbox"] {
-	width: 18px;
-	height: 18px;
-	cursor: pointer;
-	margin: 0;
-}
-.fu-inline-colour {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 14px;
-	font-weight: 500;
-	color: #475569;
-	margin: 0;
-}
-.fu-inline-colour input[type="color"] {
-	width: 36px;
-	height: 28px;
-	padding: 2px;
-	border: 1px solid var(--border-color);
-	border-radius: 4px;
-	cursor: pointer;
-	background: transparent;
-}
-
-/* Toggle pill — same look as the cropper's compact toggle */
-.fu-toggle-pill {
+/* Toggle pill (same DOM as cropper) */
+.file-uploader .toggle-pill {
 	display: inline-flex;
 	align-items: center;
 	cursor: pointer;
 }
-.fu-toggle-pill.is-disabled {
+.file-uploader .toggle-pill.is-disabled {
 	cursor: not-allowed;
 	opacity: 0.55;
 }
-.fu-toggle-track {
+.file-uploader .toggle-pill-switch {
+	display: inline-flex;
+}
+.file-uploader .toggle-pill-track {
 	display: inline-block;
 	width: 40px;
 	height: 22px;
@@ -1558,8 +1568,8 @@ export default {
 	position: relative;
 	transition: background 0.2s ease;
 }
-.fu-toggle-track.on { background: var(--primary); }
-.fu-toggle-thumb {
+.file-uploader .toggle-pill-track.on { background: var(--primary); }
+.file-uploader .toggle-pill-thumb {
 	position: absolute;
 	top: 3px;
 	left: 3px;
@@ -1569,7 +1579,168 @@ export default {
 	background: #fff;
 	transition: transform 0.2s ease;
 }
-.fu-toggle-track.on .fu-toggle-thumb { transform: translateX(18px); }
+.file-uploader .toggle-pill-track.on .toggle-pill-thumb {
+	transform: translateX(18px);
+}
+
+/* Slider row (label | slider | value) */
+.file-uploader .wm-slider-row {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 6px;
+}
+.file-uploader .wm-slider-row:last-child { margin-bottom: 0; }
+.file-uploader .wm-slider-label {
+	width: 100px;
+	font-size: 15px;
+	font-weight: 500;
+	color: #475569;
+}
+.file-uploader .wm-slider {
+	flex: 1;
+	height: 4px;
+	cursor: pointer;
+	accent-color: var(--primary);
+}
+.file-uploader .wm-slider-value {
+	width: 52px;
+	font-size: 14px;
+	font-weight: 500;
+	color: #303133;
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
+/* Font family dropdown that lives in a wm-slider-row slot */
+.file-uploader .wm-select-inline {
+	flex: 1;
+	padding: 7px 10px;
+	font-size: 14px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: #fff;
+	color: #303133;
+	cursor: pointer;
+}
+.file-uploader .wm-select-inline:focus {
+	outline: none;
+	border-color: var(--primary);
+	box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+/* Segmented mode selector (Tiled/Corner, Aspect 1:1/4:3/…, Align L/C/R) */
+.file-uploader .segmented-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	background: var(--gray-100, #f3f4f6);
+	padding: 3px;
+	border-radius: 8px;
+	gap: 2px;
+}
+.file-uploader .segmented-tab {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 18px;
+	border: none;
+	border-radius: 6px;
+	font-size: 14px;
+	font-weight: 500;
+	color: var(--text-color);
+	background: transparent;
+	cursor: pointer;
+	transition: all 0.18s ease;
+	white-space: nowrap;
+}
+.file-uploader .segmented-tab:hover {
+	background: var(--gray-200, #e5e7eb);
+}
+.file-uploader .segmented-tab.active {
+	background: var(--primary);
+	color: #fff;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+/* Row of inline check/color fields (B / I / Color ▣ / Solid BG ☑) */
+.file-uploader .wm-inline-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 14px;
+	align-items: center;
+	margin-top: 6px;
+}
+.file-uploader .wm-inline-check {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 14px;
+	font-weight: 500;
+	color: #475569;
+	cursor: pointer;
+	margin: 0;
+}
+.file-uploader .wm-inline-check input[type="checkbox"] {
+	width: 18px;
+	height: 18px;
+	margin: 0;
+	cursor: pointer;
+}
+.file-uploader .wm-inline-colour {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 14px;
+	font-weight: 500;
+	color: #475569;
+	margin: 0;
+}
+.file-uploader .wm-inline-colour input[type="color"] {
+	width: 36px;
+	height: 28px;
+	padding: 2px;
+	border: 1px solid var(--border-color);
+	border-radius: 4px;
+	cursor: pointer;
+	background: transparent;
+}
+
+/* Adjustments sub-rows (padding, watermark content, comment content…) */
+.file-uploader .adjustments-row {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.file-uploader .adjustments-row-wm {
+	gap: 10px;
+}
+.file-uploader .adjustments-warn {
+	font-size: 13px;
+	color: var(--text-muted);
+	padding: 10px 12px;
+	background: #f8fafc;
+	border-radius: 6px;
+}
+.file-uploader .adjustments-field-label {
+	display: block;
+	margin: 0 0 6px;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--text-color);
+}
+
+/* Panel action row (Reset / Save as Default) */
+.file-uploader .wm-panel-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 12px;
+}
+.file-uploader .wm-panel-actions .btn-xs {
+	font-size: 13px;
+	padding: 5px 14px;
+	line-height: 1.6;
+}
 
 /* ── Recap card (Step 3) ────────────────────────────────────────── */
 .fu-recap-card {
@@ -1638,21 +1809,14 @@ export default {
 		min-height: 0;
 		padding: 14px;
 	}
-	.fu-feature-tabs {
-		grid-template-columns: repeat(4, 1fr);
-	}
-	.fu-feature-tab { padding: 10px 4px; }
-	.fu-feature-tab-label { font-size: 14px; }
-	.fu-feature-tab-state { font-size: 12px; }
-	.fu-tab-enable-label { font-size: 15px; }
-	.fu-tab-note { font-size: 13px; }
-	.fu-recap-list li { font-size: 14px; padding: 10px 12px; }
-	.fu-slider-row {
-		grid-template-columns: 84px 1fr 44px;
-		gap: 8px;
-	}
-	.fu-slider-label { font-size: 13px; }
-	.fu-slider-value { font-size: 12px; }
+	.file-uploader .cropper-feature-tab { padding: 8px 4px; }
+	.file-uploader .cropper-feature-tab-label { font-size: 14px; }
+	.file-uploader .cropper-feature-tab-state { font-size: 12px; }
+	.file-uploader .cropper-tab-enable-label { font-size: 15px; }
+	.file-uploader .fu-recap-list li { font-size: 14px; padding: 10px 12px; }
+	.file-uploader .wm-slider-label { width: 82px; font-size: 13px; }
+	.file-uploader .wm-slider-value { width: 44px; font-size: 12px; }
+	.file-uploader .segmented-tab { padding: 7px 12px; font-size: 13px; }
 }
 
 .file-upload-area {

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -263,6 +263,25 @@
 									: __("off") }}
 							</span>
 						</li>
+						<li>
+							<span class="fu-recap-dot on"></span>
+							<span class="fu-recap-label">{{ __("Crop ratio") }}</span>
+							<span class="fu-recap-value">{{ recap.crop_aspect || "Free" }}</span>
+						</li>
+						<li :class="{ off: !recap.solid_background }">
+							<span class="fu-recap-dot" :class="recap.solid_background ? 'on' : 'off'"></span>
+							<span class="fu-recap-label">{{ __("Solid background") }}</span>
+							<span class="fu-recap-value">
+								<template v-if="recap.solid_background">
+									<span
+										class="fu-recap-swatch"
+										:style="{ backgroundColor: recap.background_color || '#FFFFFF' }"
+									></span>
+									{{ recap.background_color || "#FFFFFF" }}
+								</template>
+								<template v-else>{{ __("off") }}</template>
+							</span>
+						</li>
 					</ul>
 				</div>
 			</template>
@@ -484,9 +503,9 @@
 			:show_remove_bg="show_remove_bg && !remove_bg_disabled_hint"
 			:remove_bg_checked="remove_bg_checked"
 			:remove_bg_padding_pct="step1_padding_pct"
-			:default_crop_aspect="default_crop_aspect"
-			:default_solid_background="default_solid_background"
-			:default_background_color="default_background_color"
+			:default_crop_aspect="local_crop_aspect"
+			:default_solid_background="local_solid_background"
+			:default_background_color="local_background_color"
 			:show_watermark="show_watermark"
 			:watermark_settings="local_watermark_settings"
 			:wm_default_enabled="wm_enabled"
@@ -687,6 +706,14 @@ export default {
 			local_comment_defaults: this.comment_defaults
 				? JSON.parse(JSON.stringify(this.comment_defaults))
 				: null,
+			// Local mirrors of the three Crop-toolbar defaults so we can
+			// update them after every @crop_committed — reopening the
+			// cropper then seeds the toolbar with what the user last
+			// committed, not the original prop value. Props are read-only
+			// in Vue 2, so we need the local copy.
+			local_crop_aspect: this.default_crop_aspect || "Free",
+			local_solid_background: !!this.default_solid_background,
+			local_background_color: this.default_background_color || "#FFFFFF",
 		};
 	},
 	created() {
@@ -757,6 +784,12 @@ export default {
 				comments_enabled: s.comments_enabled != null ? s.comments_enabled : this.comments_enabled_default,
 				comment_count: s.comment_count || 0,
 				crop_aspect: s.crop_aspect || this.default_crop_aspect || "Free",
+				solid_background: s.solid_background != null
+					? s.solid_background
+					: !!this.default_solid_background,
+				background_color: s.background_color
+					|| this.default_background_color
+					|| "#FFFFFF",
 			};
 		},
 		// Tab objects used by the v-for in the template. Each entry knows
@@ -808,13 +841,42 @@ export default {
 		_on_crop_committed(snapshot) {
 			this.last_crop_settings = snapshot;
 			// Keep Step 1 / recap toggle dots in sync with the cropper's
-			// final state so a user clicking Back sees what they last
-			// committed, not the pre-crop defaults.
+			// final state so a user clicking Back (or Crop again after
+			// the cropper re-mounts) sees what they last committed, not
+			// the pre-crop defaults.
 			this.remove_bg_checked = !!snapshot.remove_bg;
 			this.wm_enabled = !!snapshot.watermark_enabled;
 			this.comments_enabled_default = !!snapshot.comments_enabled;
-			if (this.local_watermark_settings && snapshot.watermark_mode) {
+			// Watermark: merge the full per-slider state into the local
+			// settings object so re-opening the cropper restores exactly
+			// what the user tuned (opacity / size / position / mode / etc.).
+			if (this.local_watermark_settings && snapshot.watermark_state) {
+				const ws = snapshot.watermark_state;
+				Object.keys(ws).forEach((k) => {
+					if (ws[k] != null) {
+						this.$set(this.local_watermark_settings, k, ws[k]);
+					}
+				});
+			} else if (this.local_watermark_settings && snapshot.watermark_mode) {
 				this.$set(this.local_watermark_settings, "mode", snapshot.watermark_mode);
+			}
+			// Comments: carry the full edited box list forward so the next
+			// cropper mount seeds via initial_comment_boxes with what the
+			// user actually wrote, not the original preset library.
+			if (Array.isArray(snapshot.comment_boxes)) {
+				this.step1_comment_boxes = snapshot.comment_boxes.map((b) => ({ ...b }));
+			}
+			// Carry the Crop-toolbar state forward. Without this, reopening
+			// the cropper after Step 3 would reset aspect / solid bg /
+			// colour back to the original Settings-seeded prop values.
+			if (snapshot.crop_aspect) {
+				this.local_crop_aspect = snapshot.crop_aspect;
+			}
+			if (snapshot.solid_background != null) {
+				this.local_solid_background = !!snapshot.solid_background;
+			}
+			if (snapshot.background_color) {
+				this.local_background_color = snapshot.background_color;
 			}
 		},
 		_set_wm_field(field, value) {
@@ -1701,6 +1763,17 @@ export default {
 	text-transform: uppercase;
 	letter-spacing: 0.03em;
 	font-weight: 500;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+.fu-recap-swatch {
+	display: inline-block;
+	width: 14px;
+	height: 14px;
+	border-radius: 3px;
+	border: 1px solid #cbd5e1;
+	flex-shrink: 0;
 }
 
 /* ── Mobile: stack right column below left ─────────────────────── */

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -498,7 +498,7 @@
 						</div>
 						<div v-if="resize_enabled_default && local_resize_settings" class="adjustments-row">
 							<label class="adjustments-field-label">{{ __("Aspect") }}</label>
-							<div class="segmented-tabs" role="tablist">
+							<div class="segmented-tabs segmented-tabs-aspect" role="tablist">
 								<button v-for="opt in ['1:1', '4:3', '16:9', '3:2', '2:3', 'Free']" :key="opt"
 									type="button" class="segmented-tab"
 									:class="{ active: (local_resize_settings.resize_aspect || '1:1') === opt }"
@@ -1664,6 +1664,18 @@ export default {
 	background: var(--primary);
 	color: #fff;
 	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+/* Aspect row has 6 options — shrink padding so all fit on one line at the
+   ~380px right-panel width instead of wrapping "Free" to a new row. */
+.file-uploader .segmented-tabs-aspect {
+	display: grid;
+	grid-template-columns: repeat(6, 1fr);
+}
+.file-uploader .segmented-tabs-aspect .segmented-tab {
+	padding: 8px 0;
+	justify-content: center;
+	font-size: 13px;
 }
 
 /* Row of inline check/color fields (B / I / Color ▣ / Solid BG ☑) */

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -224,6 +224,8 @@
 			:show_watermark="show_watermark"
 			:watermark_settings="watermark_settings"
 			:wm_default_enabled="wm_enabled"
+			:show_resize="show_resize"
+			:resize_settings="resize_settings"
 			@toggle_image_cropper="toggle_image_cropper(-1)"
 			@upload_after_crop="trigger_upload = true"
 			@remove_bg_changed="remove_bg_checked = $event"
@@ -311,6 +313,14 @@ export default {
 			default: false,
 		},
 		watermark_settings: {
+			default: null,
+		},
+		// Output Shape (new 2026-04) — aspect normalization applied at
+		// Crop time. Mirror of Image Processing Settings' resize_* fields.
+		show_resize: {
+			default: false,
+		},
+		resize_settings: {
 			default: null,
 		},
 	},

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -1004,4 +1004,35 @@ export default {
 	font-weight: 500;
 	border-radius: 8px;
 }
+
+/* The File Uploader dialog now hosts ImageCropper + its side panel; the default
+   modal-dialog (typically 600px wide) is too small. Expand up to 90vw / 90vh
+   with a hard ceiling of 1600 × 900 so it doesn't dominate 4K displays. */
+.file-uploader-dialog .modal-dialog {
+	max-width: min(90vw, 1600px);
+	width: min(90vw, 1600px);
+	margin: 1.75rem auto;
+}
+.file-uploader-dialog .modal-content {
+	max-height: min(90vh, 900px);
+	min-height: min(90vh, 900px);
+	display: flex;
+	flex-direction: column;
+}
+.file-uploader-dialog .modal-body {
+	flex: 1 1 auto;
+	overflow-y: auto;
+}
+@media (max-width: 768px) {
+	.file-uploader-dialog .modal-dialog {
+		max-width: 100vw;
+		width: 100vw;
+		margin: 0;
+	}
+	.file-uploader-dialog .modal-content {
+		min-height: 100vh;
+		max-height: 100vh;
+		border-radius: 0;
+	}
+}
 </style>

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -2160,8 +2160,15 @@ export default {
 }
 .file-uploader-dialog .modal-body {
 	flex: 1 1 auto;
+	min-height: 0;
 	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
 }
+/* When the ImageCropper mounts, its .cropper-grid should fill the body so
+   the left column can distribute height (toolbar / image / preview). */
+.file-uploader-dialog .modal-body > .file-uploader { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+.file-uploader-dialog .modal-body > .file-uploader > .cropper-grid { flex: 1 1 auto; min-height: 0; }
 /* Footer region — standard-actions holds the primary Upload button,
    custom-actions holds the feature toggles (Watermark / Remove BG
    pills). Space them properly so they don't collide, and wrap on

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -2756,6 +2756,9 @@ img {
 .canvas-segmented .segmented-tab {
 	flex: 1 0 auto;
 	min-width: 48px;
+	padding: 7px 0;
+	justify-content: center;
+	font-size: 13px;
 }
 .canvas-misc-row {
 	display: flex;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -997,8 +997,13 @@ export default {
 			// consumers (any app that embeds <image-cropper> in its own
 			// page/dialog without the .file-uploader wrapper) keep their
 			// default modal-body + modal-footer layout untouched.
-			const body = this.$el.closest && this.$el.closest(".file-uploader .modal-body");
-			if (body) {
+			//
+			// DOM layout is .modal-body > .file-uploader > ...cropper
+			// — walk up to the modal-body, then confirm our .file-uploader
+			// container is a descendant of it (guards against running
+			// inside an unrelated dialog that happens to have .modal-body).
+			const body = this.$el.closest && this.$el.closest(".modal-body");
+			if (body && body.querySelector(".file-uploader")) {
 				body.classList.add("image-cropper-modal-body");
 				this._modal_body_el = body;
 			}
@@ -3077,9 +3082,12 @@ img {
 	   photo with room to drag the crop box; we also enforce an
 	   absolute 400px floor so short viewports (≤720px tall) still get
 	   a workable canvas, and cap at 600px so mid-sized tablets don't
-	   get a cropper that dwarfs the controls below it. */
+	   get a cropper that dwarfs the controls below it.
+	   !important because the desktop rule (.cropper-image-stage {
+	   min-height: 0 }) sits lower in source order and would otherwise
+	   win the cascade on equal specificity. */
 	.cropper-image-stage {
-		min-height: max(400px, 55vh);
+		min-height: max(400px, 55vh) !important;
 		max-height: 600px;
 	}
 	.cropper-image-wrapper {
@@ -3104,7 +3112,7 @@ img {
 	   users aren't cropping in a tiny viewport. Cap tighter since
 	   phones have less vertical space overall. */
 	.cropper-image-stage {
-		min-height: max(400px, 50vh);
+		min-height: max(400px, 50vh) !important;
 		max-height: 520px;
 	}
 	.cropper-preview-canvas,

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -374,6 +374,13 @@
 									@input="wm_pos_y = parseFloat($event.target.value)" />
 								<span class="wm-slider-value">{{ Math.round(wm_pos_y) }}%</span>
 							</div>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Rotation") }}</label>
+								<input type="range" class="wm-slider" min="-180" max="180" step="5"
+									:value="wm_corner_rotation"
+									@input="wm_corner_rotation = parseFloat($event.target.value)" />
+								<span class="wm-slider-value">{{ Math.round(wm_corner_rotation) }}°</span>
+							</div>
 						</template>
 
 						<div class="wm-panel-actions">
@@ -673,6 +680,7 @@ export default {
 			wm_img: null,
 			wm_pos_x: 80,
 			wm_pos_y: 90,
+			wm_corner_rotation: 0,
 			wm_size: 20,
 			wm_opacity: 50,
 			wm_dragging: false,
@@ -745,6 +753,7 @@ export default {
 		wm_size() { this._schedule_preview_update(); },
 		wm_pos_x() { this._schedule_preview_update(); },
 		wm_pos_y() { this._schedule_preview_update(); },
+		wm_corner_rotation() { this._schedule_preview_update(); this.wm_redraw(); },
 		wm_mode() { this._schedule_preview_update(); },
 		wm_tile_size() { this._schedule_preview_update(); },
 		wm_tile_opacity() { this._schedule_preview_update(); },
@@ -790,6 +799,9 @@ export default {
 			// Corner params
 			this.wm_pos_x = this.watermark_settings.position_x || 80;
 			this.wm_pos_y = this.watermark_settings.position_y || 90;
+			this.wm_corner_rotation = this.watermark_settings.corner_rotation != null
+				? this.watermark_settings.corner_rotation
+				: 0;
 			this.wm_size = this.watermark_settings.size || 20;
 			this.wm_opacity = this.watermark_settings.opacity || 50;
 			// Tiled params
@@ -1148,9 +1160,18 @@ export default {
 					const draw_y = (wm_center_y - wm_h_full / 2 - crop_y) * scale_y;
 					const draw_w = wm_w_full * scale_x;
 					const draw_h = wm_h_full * scale_y;
+					const rot = (this.wm_corner_rotation || 0) * Math.PI / 180;
+					ctx.save();
 					ctx.globalAlpha = this.wm_opacity / 100;
+					if (rot) {
+						const cx = draw_x + draw_w / 2;
+						const cy = draw_y + draw_h / 2;
+						ctx.translate(cx, cy);
+						ctx.rotate(rot);
+						ctx.translate(-cx, -cy);
+					}
 					ctx.drawImage(this.wm_img, draw_x, draw_y, draw_w, draw_h);
-					ctx.globalAlpha = 1.0;
+					ctx.restore();
 				}
 			}
 
@@ -1755,9 +1776,20 @@ export default {
 				const draw_y = (wm_center_y - wm_h_full / 2 - crop_y) * scale_y;
 				const draw_w = wm_w_full * scale_x;
 				const draw_h = wm_h_full * scale_y;
+				const rot = (this.wm_corner_rotation || 0) * Math.PI / 180;
+				ctx.save();
 				ctx.globalAlpha = this.wm_opacity / 100;
+				if (rot) {
+					// Rotate around the watermark's center, matching PIL's
+					// rotate(-deg, expand=True) + recentre in _apply_watermark.
+					const cx = draw_x + draw_w / 2;
+					const cy = draw_y + draw_h / 2;
+					ctx.translate(cx, cy);
+					ctx.rotate(rot);
+					ctx.translate(-cx, -cy);
+				}
 				ctx.drawImage(this.wm_img, draw_x, draw_y, draw_w, draw_h);
-				ctx.globalAlpha = 1.0;
+				ctx.restore();
 			}
 		},
 
@@ -1885,6 +1917,16 @@ export default {
 		},
 		wm_draw_corner(ctx, cd) {
 			const r = this.wm_get_rect_in_container(cd);
+			const rot = (this.wm_corner_rotation || 0) * Math.PI / 180;
+			const cx = r.x + r.w / 2;
+			const cy = r.y + r.h / 2;
+
+			ctx.save();
+			if (rot) {
+				ctx.translate(cx, cy);
+				ctx.rotate(rot);
+				ctx.translate(-cx, -cy);
+			}
 			ctx.globalAlpha = this.wm_opacity / 100;
 			ctx.drawImage(this.wm_img, r.x, r.y, r.w, r.h);
 			ctx.globalAlpha = 1.0;
@@ -1913,6 +1955,7 @@ export default {
 					ctx.fillRect(hx - handle / 2, hy - handle / 2, handle, handle);
 				});
 			}
+			ctx.restore();
 		},
 		wm_draw_tiled(ctx, cd) {
 			const tile_w = (this.wm_tile_size / 100) * cd.width;
@@ -2113,6 +2156,7 @@ export default {
 							mode: this.wm_mode,
 							position_x: Math.round(this.wm_pos_x * 10) / 10,
 							position_y: Math.round(this.wm_pos_y * 10) / 10,
+							corner_rotation: Math.round(this.wm_corner_rotation || 0),
 							size: Math.round(this.wm_size * 10) / 10,
 							opacity: this.wm_opacity,
 							tile_size: Math.round(this.wm_tile_size * 10) / 10,
@@ -2127,6 +2171,7 @@ export default {
 						mode: this.wm_mode,
 						position_x: this.wm_pos_x,
 						position_y: this.wm_pos_y,
+						corner_rotation: this.wm_corner_rotation || 0,
 						size: this.wm_size,
 						opacity: this.wm_opacity,
 						tile_size: this.wm_tile_size,
@@ -2146,6 +2191,7 @@ export default {
 				this.wm_mode = s.mode || "Corner";
 				this.wm_pos_x = s.position_x || 80;
 				this.wm_pos_y = s.position_y || 90;
+				this.wm_corner_rotation = s.corner_rotation != null ? s.corner_rotation : 0;
 				this.wm_size = s.size || 20;
 				this.wm_opacity = s.opacity || 50;
 				this.wm_tile_size = s.tile_size || 15;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -62,7 +62,7 @@
 		     Watermark) live in the sticky dialog footer; this panel only hosts
 		     the parameters for whichever features are currently on. -->
 		<div
-			v-if="(show_remove_bg && bg_removed && nobg_bbox) || (show_watermark && wm_enabled) || (show_resize && resize_enabled)"
+			v-if="(show_remove_bg && bg_removed && nobg_bbox) || (show_watermark && wm_enabled) || (show_resize && resize_enabled) || (show_comments && comments_enabled)"
 			class="adjustments-panel"
 		>
 			<!-- Live preview of the final output (what Crop will produce).
@@ -137,6 +137,112 @@
 						<input type="checkbox" v-model="resize_flatten_rgb" />
 						<span>{{ __("Flatten RGB") }}</span>
 					</label>
+				</div>
+			</div>
+
+			<!-- Comments (new 2026-04) — simple list editor for single-item
+			     upload. Each entry is a text overlay with position/size/font
+			     controls. No drag UI here (use Item Image Batch for that).
+			     Baked into the Canvas composite on Crop click. -->
+			<div
+				v-if="show_comments && comments_enabled"
+				class="adjustments-row adjustments-row-comments"
+			>
+				<label class="adjustments-field-label">
+					{{ __("Comments") }}
+					<span class="adjustments-field-hint">
+						{{ __("Text baked into the image on Crop.") }}
+					</span>
+				</label>
+
+				<div v-if="comment_boxes.length === 0" class="comments-empty-hint">
+					{{ __("No comments yet.") }}
+				</div>
+
+				<div
+					v-for="(box, i) in comment_boxes"
+					:key="'box-' + i"
+					class="comment-entry"
+				>
+					<div class="comment-entry-header">
+						<span class="comment-entry-idx">#{{ i + 1 }}</span>
+						<textarea
+							class="comment-text-input"
+							:value="box.text"
+							:placeholder="__('Text…')"
+							rows="1"
+							@input="_update_comment(i, 'text', $event.target.value)"
+						></textarea>
+						<button
+							type="button"
+							class="btn btn-xs btn-danger comment-delete"
+							:title="__('Delete comment')"
+							@click="_delete_comment(i)"
+						>×</button>
+					</div>
+					<div class="comment-entry-controls">
+						<label class="comment-control">
+							<span>{{ __("Size %") }}</span>
+							<input type="number" class="wm-input comment-num-input"
+								min="1" max="50" step="0.5"
+								:value="box.font_size_pct"
+								@input="_update_comment(i, 'font_size_pct', parseFloat($event.target.value) || 5.0)"
+							/>
+						</label>
+						<label class="comment-control">
+							<span>X%</span>
+							<input type="number" class="wm-input comment-num-input"
+								min="0" max="100" step="1"
+								:value="Math.round(box.position_x_pct)"
+								@input="_update_comment(i, 'position_x_pct', parseFloat($event.target.value) || 0)"
+							/>
+						</label>
+						<label class="comment-control">
+							<span>Y%</span>
+							<input type="number" class="wm-input comment-num-input"
+								min="0" max="100" step="1"
+								:value="Math.round(box.position_y_pct)"
+								@input="_update_comment(i, 'position_y_pct', parseFloat($event.target.value) || 0)"
+							/>
+						</label>
+						<label class="comment-control">
+							<input type="checkbox"
+								:checked="box.font_weight === 'Bold'"
+								@change="_update_comment(i, 'font_weight', $event.target.checked ? 'Bold' : 'Normal')"
+							/>
+							<span>B</span>
+						</label>
+						<label class="comment-control">
+							<input type="color"
+								:value="box.color"
+								@input="_update_comment(i, 'color', $event.target.value)"
+							/>
+						</label>
+					</div>
+				</div>
+
+				<div class="comments-actions">
+					<button type="button" class="btn btn-xs btn-primary-light" @click="_add_comment()">
+						+ {{ __("Add Comment") }}
+					</button>
+					<button
+						v-if="comment_presets && comment_presets.length"
+						type="button"
+						class="btn btn-xs btn-default"
+						@click="_toggle_preset_menu()"
+					>
+						📋 {{ __("Presets") }}
+					</button>
+					<div v-if="preset_menu_open" class="comment-preset-menu">
+						<div
+							v-for="(p, pi) in comment_presets"
+							:key="'preset-' + pi"
+							class="comment-preset-item"
+							@click="_insert_preset(p)"
+						>
+							{{ p.text || __("(no text)") }}
+						</div>
+					</div>
 				</div>
 			</div>
 
@@ -346,6 +452,25 @@
 						</span>
 					</span>
 				</div>
+				<div
+					v-if="show_comments"
+					class="toggle-pill"
+					:class="{ active: comments_enabled }"
+					@click="comments_enabled = !comments_enabled"
+					:title="__('Add text comments baked into the image')"
+				>
+					<span class="toggle-pill-label">
+						{{ __("Comments") }}
+						<span v-if="comments_enabled && comment_boxes.length > 0" class="toggle-pill-sublabel">
+							{{ comment_boxes.length }}
+						</span>
+					</span>
+					<span class="toggle-pill-switch">
+						<span class="toggle-pill-track" :class="{ on: comments_enabled }">
+							<span class="toggle-pill-thumb"></span>
+						</span>
+					</span>
+				</div>
 			</div>
 			<div>
 				<button
@@ -371,8 +496,13 @@ export default {
 		"file", "fixed_aspect_ratio",
 		"show_remove_bg", "remove_bg_checked", "remove_bg_padding_pct",
 		"show_watermark", "watermark_settings", "wm_default_enabled",
-		// Output Shape (new 2026-04) — from Image Processing Settings via item.js
+		// Resize (new 2026-04) — from Image Processing Settings via item.js
 		"show_resize", "resize_settings",
+		// Comments (new 2026-04) — simple list of text overlays baked into
+		// the final output. The single-item flow uses a lightweight
+		// textarea-based editor (no drag). Batch flow uses the full
+		// CommentBoxEditor with draggable handles.
+		"show_comments", "comment_defaults", "comment_presets",
 	],
 	data() {
 		return {
@@ -431,6 +561,13 @@ export default {
 			// change so the user sees exactly what Crop will produce.
 			preview_dims: null,
 			_preview_debounce: null,
+			// Comments (new 2026-04) — simple list baked into the final
+			// Canvas composite. No drag UI here; edits via textarea + number
+			// inputs. For the full drag/resize experience, use the Item
+			// Image Batch.
+			comments_enabled: false,
+			comment_boxes: [],
+			preset_menu_open: false,
 		};
 	},
 	watch: {
@@ -460,6 +597,11 @@ export default {
 		wm_tile_spacing() { this._schedule_preview_update(); },
 		local_padding_pct() { this._schedule_preview_update(); },
 		bg_removed() { this._schedule_preview_update(); },
+		comments_enabled() { this._schedule_preview_update(); },
+		comment_boxes: {
+			handler() { this._schedule_preview_update(); },
+			deep: true,
+		},
 	},
 	mounted() {
 		// Remove BG: cached files + bbox metadata (Phase 1)
@@ -496,7 +638,7 @@ export default {
 			this.load_watermark_image(this.watermark_settings.watermark_image);
 		}
 
-		// Output Shape: load settings (new 2026-04)
+		// Resize: load settings (new 2026-04)
 		if (this.show_resize && this.resize_settings) {
 			this.resize_enabled = !!this.resize_settings.resize_enabled;
 			this.resize_aspect = this.resize_settings.resize_aspect || "1:1";
@@ -505,6 +647,12 @@ export default {
 			this.resize_flatten_rgb = !!this.resize_settings.resize_flatten_rgb;
 			this.max_file_size_kb = this.resize_settings.max_file_size_kb || 2048;
 		}
+
+		// Comments: off by default on new uploads. The user has to opt in
+		// each time (unlike Resize which follows the Settings default)
+		// because comments carry meaning — users shouldn't accidentally
+		// bake a previous session's text onto a new photo.
+		// comment_boxes starts empty; user adds them with + Add Comment.
 
 		// Global listeners for watermark drag
 		this._on_mousemove = this.on_wrapper_mousemove.bind(this);
@@ -766,11 +914,20 @@ export default {
 				}
 			}
 
-			// ── Output Shape step (new 2026-04) ──
+			// ── Comments step (new 2026-04) ──
+			// Bake text overlays onto the cropped canvas BEFORE aspect
+			// normalization, so box positions stay attached to product
+			// content (not to Contain-padded fill strips).
+			if (this.show_comments && this.comments_enabled && this.comment_boxes.length > 0) {
+				const cctx = canvas.getContext("2d");
+				this._composite_comments_on_canvas(canvas, cctx);
+			}
+
+			// ── Resize step (new 2026-04) ──
 			// Apply aspect normalization + optional RGB flatten to a fresh
 			// canvas that mirrors the server-side PIL helper in
 			// item_image_batch.py::_apply_aspect_normalize. Happens AFTER the
-			// watermark composite (so comments / watermark stay on product
+			// watermark + comments composites (so both stay on product
 			// content, not on Contain-padded fill strips).
 			let final_canvas = canvas;
 			if (this.show_resize && this.resize_enabled) {
@@ -910,6 +1067,112 @@ export default {
 			return out;
 		},
 
+		// ── Comments (new 2026-04) ──
+		_add_comment() {
+			const d = this.comment_defaults || {};
+			this.comment_boxes.push({
+				text: "",
+				position_x_pct: 50,
+				position_y_pct: 50,
+				width_pct: 40,
+				height_pct: 10,
+				font_family: d.font_family || "Arial",
+				font_size_pct: d.font_size_pct || 5.0,
+				font_weight: d.font_weight || "Normal",
+				font_style: d.font_style || "Normal",
+				color: d.color || "#000000",
+				align: d.align || "Center",
+			});
+		},
+		_update_comment(i, field, value) {
+			const current = this.comment_boxes[i];
+			if (!current) return;
+			this.$set(this.comment_boxes, i, { ...current, [field]: value });
+		},
+		_delete_comment(i) {
+			this.comment_boxes.splice(i, 1);
+		},
+		_toggle_preset_menu() {
+			this.preset_menu_open = !this.preset_menu_open;
+		},
+		_insert_preset(preset) {
+			this.comment_boxes.push({
+				text: preset.text || "",
+				position_x_pct: preset.position_x_pct ?? 50,
+				position_y_pct: preset.position_y_pct ?? 50,
+				width_pct: preset.width_pct ?? 40,
+				height_pct: preset.height_pct ?? 10,
+				font_family: preset.font_family || "Arial",
+				font_size_pct: preset.font_size_pct ?? 5.0,
+				font_weight: preset.font_weight || "Normal",
+				font_style: preset.font_style || "Normal",
+				color: preset.color || "#000000",
+				align: preset.align || "Center",
+			});
+			this.preset_menu_open = false;
+		},
+
+		// Paint all enabled comment boxes onto the cropped canvas. Called
+		// after watermark compositing, before aspect normalize, so boxes
+		// stay attached to content (not Contain-padded fill strips).
+		// Mirrors the server-side _apply_comment_boxes in item_image_batch.py.
+		_composite_comments_on_canvas(canvas, ctx) {
+			if (!this.comment_boxes || this.comment_boxes.length === 0) return;
+			const w = canvas.width;
+			const h = canvas.height;
+			for (const box of this.comment_boxes) {
+				if (!box.text) continue;
+				const font_size_px = Math.max(1, Math.round(h * (box.font_size_pct || 5.0) / 100));
+				const family = box.font_family || "Arial";
+				const weight = box.font_weight === "Bold" ? "bold" : "normal";
+				const style = box.font_style === "Italic" ? "italic" : "normal";
+				ctx.font = `${style} ${weight} ${font_size_px}px "${family}", sans-serif`;
+				ctx.fillStyle = box.color || "#000000";
+
+				const cx = w * (box.position_x_pct || 50) / 100;
+				const cy = h * (box.position_y_pct || 50) / 100;
+				const box_w_px = w * (box.width_pct || 40) / 100;
+
+				// Simple greedy word-wrap (same intent as _wrap_to_width on server)
+				const lines = this._wrap_text_to_width(
+					String(box.text || ""), box_w_px, ctx
+				);
+				const line_h = font_size_px * 1.2;
+				const total_h = lines.length * line_h;
+				let y_cursor = cy - total_h / 2 + line_h * 0.75;
+				for (const line of lines) {
+					const line_w = ctx.measureText(line).width;
+					let x;
+					if (box.align === "Left") x = cx - box_w_px / 2;
+					else if (box.align === "Right") x = cx + box_w_px / 2 - line_w;
+					else x = cx - line_w / 2;
+					ctx.fillText(line, x, y_cursor);
+					y_cursor += line_h;
+				}
+			}
+		},
+
+		_wrap_text_to_width(text, max_width_px, ctx) {
+			if (!text) return [];
+			const out = [];
+			for (const paragraph of text.split("\n")) {
+				if (!paragraph) { out.push(""); continue; }
+				const words = paragraph.split(" ");
+				let line = "";
+				for (const word of words) {
+					const candidate = line ? `${line} ${word}` : word;
+					if (ctx.measureText(candidate).width <= max_width_px || !line) {
+						line = candidate;
+					} else {
+						out.push(line);
+						line = word;
+					}
+				}
+				if (line) out.push(line);
+			}
+			return out;
+		},
+
 		// ── Live preview (new 2026-04) ──
 		_schedule_preview_update() {
 			if (this._preview_debounce) clearTimeout(this._preview_debounce);
@@ -943,6 +1206,11 @@ export default {
 			wctx.drawImage(src, 0, 0);
 			if (this.wm_enabled && this.wm_loaded && this.wm_img) {
 				this._composite_watermark_on_canvas(work, wctx);
+			}
+			// Comments — baked BEFORE Resize so box positions stay attached
+			// to product content, not to Contain-padded fill strips.
+			if (this.show_comments && this.comments_enabled) {
+				this._composite_comments_on_canvas(work, wctx);
 			}
 
 			// Apply Resize (same helper used on final crop)
@@ -1957,6 +2225,105 @@ img {
 	color: #64748b;
 	text-align: center;
 	font-variant-numeric: tabular-nums;
+}
+
+/* Comments list (new 2026-04) — simple inline editor for single-item
+   uploads. Full drag/resize experience lives in the Item Image Batch
+   CommentBoxEditor.vue; here we just need fast textarea + position
+   number inputs. */
+.adjustments-row-comments {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.comments-empty-hint {
+	font-size: 12px;
+	color: #94a3b8;
+	font-style: italic;
+	padding: 4px 0;
+}
+.comment-entry {
+	border: 1px solid #e5edf8;
+	border-radius: 6px;
+	background: #fafbfc;
+	padding: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+.comment-entry-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+}
+.comment-entry-idx {
+	font-size: 11px;
+	color: #64748b;
+	font-weight: 600;
+	padding-top: 4px;
+	min-width: 20px;
+}
+.comment-text-input {
+	flex: 1;
+	padding: 4px 6px;
+	border: 1px solid #cbd5e1;
+	border-radius: 4px;
+	font-size: 13px;
+	resize: vertical;
+	min-height: 28px;
+}
+.comment-delete {
+	padding: 2px 8px;
+	line-height: 1;
+}
+.comment-entry-controls {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: center;
+}
+.comment-control {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 11px;
+	color: #606266;
+}
+.comment-num-input {
+	width: 52px;
+	padding: 2px 4px;
+	font-size: 11px;
+}
+.comments-actions {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+	position: relative;
+}
+.comment-preset-menu {
+	position: absolute;
+	top: calc(100% + 4px);
+	left: 0;
+	background: #fff;
+	border: 1px solid #cbd5e1;
+	border-radius: 4px;
+	min-width: 220px;
+	max-height: 240px;
+	overflow-y: auto;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+	z-index: 10;
+}
+.comment-preset-item {
+	padding: 6px 10px;
+	font-size: 12px;
+	cursor: pointer;
+	border-bottom: 1px solid #f1f5f9;
+}
+.comment-preset-item:hover {
+	background: #ecf5ff;
+}
+.comment-preset-item:last-child {
+	border-bottom: none;
 }
 </style>
 

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -38,10 +38,13 @@
 						<input type="checkbox" v-model="solid_background" />
 						<span>{{ __("Solid bg") }}</span>
 					</label>
+					<!-- Colour picker is always visible so the user can pre-set
+					     the colour without first flipping the toggle. Dimmed
+					     when the toggle is off to signal it's inactive. -->
 					<input
-						v-if="solid_background"
 						type="color"
 						class="cropper-toolbar-colour"
+						:class="{ 'is-dim': !solid_background }"
 						v-model="background_color"
 						:title="__('Background colour')"
 					/>
@@ -841,6 +844,12 @@ export default {
 		this.nobg_bbox = this.file._nobg_bbox || null;
 		this.nobg_natural_size = this.file._nobg_natural_size || null;
 		this.file._original_file = this.original_file;
+		// Restore any padding-slider override the user dragged before
+		// hitting Crop the last time — lives on the file so it survives
+		// Step 2 ↔ Step 3 round-trips like nobg_* above.
+		if (this.file._padding_pct_override != null) {
+			this.local_padding_pct = this.file._padding_pct_override;
+		}
 
 		if (this.remove_bg_checked && this.nobg_file) {
 			this.bg_removed = true;
@@ -1157,6 +1166,19 @@ export default {
 							!this.file.crop_box_data
 						) {
 							this._apply_auto_crop();
+						} else if (crop_box) {
+							// Re-mounting a cropper that was already cropped once
+							// (user hit Back from Step 3). CropperJS applies
+							// crop_box as natural-image-coords rect via `data:`
+							// above, but it doesn't zoom to make that rect
+							// visibly fill the workspace — default zoom fits
+							// the whole image, leaving the tight crop box
+							// floating tiny in a sea of solid-bg pixels. Auto-
+							// zoom the display so the restored crop rect sits
+							// comfortably in view like when it was first made.
+							this.$nextTick(() => {
+								this._zoom_to_fit_rect(crop_box, 0.12);
+							});
 						}
 						if (this.wm_enabled && this.wm_loaded) {
 							this.$nextTick(() => this.wm_resize_canvas());
@@ -1319,12 +1341,14 @@ export default {
 			if (!Number.isFinite(val)) return;
 			// Clamp to slider bounds
 			this.local_padding_pct = Math.max(-20, Math.min(40, val));
+			this.file._padding_pct_override = this.local_padding_pct;
 			if (this.bg_removed && this.nobg_bbox && this.cropper) {
 				this._apply_auto_crop();
 			}
 		},
 		reset_padding_pct() {
 			this.local_padding_pct = null;
+			this.file._padding_pct_override = null;
 			if (this.bg_removed && this.nobg_bbox && this.cropper) {
 				this._apply_auto_crop();
 			}
@@ -2657,22 +2681,45 @@ export default {
 	align-items: center;
 	gap: 6px;
 	margin: 0;
+	padding: 4px 10px;
 	font-size: 12px;
-	color: #303133;
+	font-weight: 500;
+	color: #606266;
+	border: 1px solid #dcdfe6;
+	border-radius: 4px;
+	background: white;
 	cursor: pointer;
 	user-select: none;
+	transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+.cropper-toolbar-toggle:hover {
+	border-color: var(--primary, #2563eb);
+	color: var(--primary, #2563eb);
+}
+.cropper-toolbar-toggle:has(input:checked) {
+	background: var(--primary-light, #ecf5ff);
+	border-color: var(--primary, #2563eb);
+	color: var(--primary, #2563eb);
 }
 .cropper-toolbar-toggle input[type="checkbox"] {
 	margin: 0;
+	accent-color: var(--primary, #2563eb);
 }
 .cropper-toolbar-colour {
-	width: 26px;
-	height: 26px;
+	width: 28px;
+	height: 28px;
 	padding: 0;
 	border: 1px solid #dcdfe6;
 	border-radius: 4px;
 	background: white;
 	cursor: pointer;
+	transition: opacity 0.12s, border-color 0.12s;
+}
+.cropper-toolbar-colour.is-dim {
+	opacity: 0.45;
+}
+.cropper-toolbar-colour:hover {
+	border-color: var(--primary, #2563eb);
 }
 .cropper-toolbar-save {
 	flex-shrink: 0;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -2022,20 +2022,39 @@ export default {
 			const scale_y = ch / crop_h;
 
 			if (this.wm_mode === "Tiled") {
-				const tile_w = (this.wm_tile_size / 100) * full_w * scale_x;
-				const tile_h = tile_w * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
-				const spacing_x = (this.wm_tile_spacing / 100) * full_w * scale_x;
-				const spacing_y = (this.wm_tile_spacing / 100) * full_h * scale_y;
-				const step_x = tile_w + spacing_x;
-				const step_y = tile_h + spacing_y;
+				// Tile size & spacing are a % of the source image's natural
+				// width, then scaled into output-canvas pixels via scale_x.
+				// Matches the overlay which anchors to getCanvasData (=
+				// naturalWidth × zoom) → WYSIWYG. Crop size and padding
+				// don't change tile dimensions; they just open a different
+				// window onto the same pattern.
+				const tile_w_natural = (this.wm_tile_size / 100) * full_w;
+				const tile_h_natural = tile_w_natural * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
+				const spacing_natural = (this.wm_tile_spacing / 100) * full_w;
+				const tile_w = tile_w_natural * scale_x;
+				const tile_h = tile_h_natural * scale_y;
+				const step_x = tile_w + spacing_natural * scale_x;
+				const step_y = tile_h + spacing_natural * scale_y;
 				const angle = (this.wm_tile_rotation * Math.PI) / 180;
+				// Pattern origin = center of the full source image projected
+				// into output coords. Keeps tile phase stable across crops
+				// (move the crop box → same tile positions relative to the
+				// image, not re-centered to the crop).
+				const origin_x = (full_w / 2 - crop_x) * scale_x;
+				const origin_y = (full_h / 2 - crop_y) * scale_y;
 				ctx.save();
 				ctx.globalAlpha = this.wm_tile_opacity / 100;
-				ctx.translate(cw / 2, ch / 2);
+				ctx.translate(origin_x, origin_y);
 				ctx.rotate(angle);
-				const diag = Math.sqrt(cw * cw + ch * ch);
-				for (let y = -diag; y < diag; y += step_y) {
-					for (let x = -diag; x < diag; x += step_x) {
+				// Reach must cover every corner of the output canvas from
+				// the (possibly off-canvas) image center.
+				const max_dist = Math.sqrt(
+					Math.max(origin_x, cw - origin_x) ** 2 +
+					Math.max(origin_y, ch - origin_y) ** 2
+				);
+				const reach = max_dist + Math.max(tile_w, tile_h);
+				for (let y = -reach; y < reach; y += step_y) {
+					for (let x = -reach; x < reach; x += step_x) {
 						ctx.drawImage(this.wm_img, x, y, tile_w, tile_h);
 					}
 				}
@@ -2180,11 +2199,24 @@ export default {
 			const ch = canvas.height;
 			ctx.clearRect(0, 0, cw, ch);
 
-			const cd = this.cropper.getCanvasData();
-
 			if (this.wm_mode === "Tiled") {
-				this.wm_draw_tiled(ctx, cd);
+				// Tile size is anchored to the image's natural width (via
+				// getCanvasData, which is naturalWidth × zoom), NOT the
+				// crop box. That way:
+				//   • Changing Auto-crop padding only moves/resizes the
+				//     crop window — the watermark pattern behind it stays
+				//     put. User sees the same tiles through a different
+				//     hole.
+				//   • Zooming the image scales the tiles with it (they're
+				//     part of the image's coord space).
+				// Tiles cover the ENTIRE overlay canvas so that any crop
+				// region the user ends up choosing shows watermark.
+				const cd = this.cropper.getCanvasData();
+				this.wm_draw_tiled(ctx, cd, cw, ch);
 			} else {
+				// Corner watermark is anchored to the image (so it moves
+				// with the product, not with the crop frame).
+				const cd = this.cropper.getCanvasData();
 				this.wm_draw_corner(ctx, cd);
 			}
 		},
@@ -2230,26 +2262,40 @@ export default {
 			}
 			ctx.restore();
 		},
-		wm_draw_tiled(ctx, cd) {
+		wm_draw_tiled(ctx, cd, container_w, container_h) {
+			// Tile dimensions are % of the image's displayed natural width
+			// (cd = cropper.getCanvasData() → naturalWidth × zoom). Spacing
+			// uses the same basis so aspect-ratio changes of the image
+			// don't warp the tile grid.
 			const tile_w = (this.wm_tile_size / 100) * cd.width;
 			const tile_h = tile_w * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
-			const spacing_x = (this.wm_tile_spacing / 100) * cd.width;
-			const spacing_y = (this.wm_tile_spacing / 100) * cd.height;
-			const step_x = tile_w + spacing_x;
-			const step_y = tile_h + spacing_y;
+			const spacing = (this.wm_tile_spacing / 100) * cd.width;
+			const step_x = tile_w + spacing;
+			const step_y = tile_h + spacing;
 			const angle = (this.wm_tile_rotation * Math.PI) / 180;
 
 			ctx.save();
 			ctx.globalAlpha = this.wm_tile_opacity / 100;
-			// Rotate around image center
-			const cx = cd.left + cd.width / 2;
-			const cy = cd.top + cd.height / 2;
-			ctx.translate(cx, cy);
+			// Pattern is anchored to the image's center (cd.left, cd.top is
+			// the image's top-left in container coords). Rotating about this
+			// origin means changing the crop window — via Auto-crop padding
+			// or moving the box — just reveals a different portion of the
+			// same stationary pattern. WYSIWYG with the bake path.
+			const ox = cd.left + cd.width / 2;
+			const oy = cd.top + cd.height / 2;
+			ctx.translate(ox, oy);
 			ctx.rotate(angle);
 
-			const diag = Math.sqrt(cd.width * cd.width + cd.height * cd.height);
-			for (let y = -diag; y < diag; y += step_y) {
-				for (let x = -diag; x < diag; x += step_x) {
+			// Reach from the image center out to the farthest container
+			// corner, so tiles cover the whole overlay (crop box can sit
+			// anywhere and still land on watermarked pixels).
+			const max_dist = Math.sqrt(
+				Math.max(ox, container_w - ox) ** 2 +
+				Math.max(oy, container_h - oy) ** 2
+			);
+			const reach = max_dist + Math.max(tile_w, tile_h);
+			for (let y = -reach; y < reach; y += step_y) {
+				for (let x = -reach; x < reach; x += step_x) {
 					ctx.drawImage(this.wm_img, x, y, tile_w, tile_h);
 				}
 			}

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1191,8 +1191,13 @@ export default {
 					viewMode: 0,
 					zoomable: true,
 					scalable: false,
-					zoomOnTouch: true,
-					zoomOnWheel: true,
+					// Our zoom toolbar + on_wrapper_wheel handle wheel/pinch
+					// explicitly (via _zoom_preserving_crop), so CropperJS's
+					// own wheel/touch zoom is turned off to avoid two code
+					// paths with different behaviour (native path doesn't
+					// track the crop box, ours does).
+					zoomOnTouch: false,
+					zoomOnWheel: false,
 					wheelZoomRatio: 0.1,
 					autoCropArea: 1,
 					data: crop_box,
@@ -2269,20 +2274,37 @@ export default {
 		},
 
 		// ── Zoom controls (viewMode:0 workspace) ──
-		// cropper.zoom(ratio) is relative (delta); zoomTo(absolute) sets
-		// display/natural. "Fit" recenters + fits the image into the
-		// container via cropper.reset(), matching the initial mount state.
-		zoom_by(delta) {
+		// cropper.zoom(delta) scales the image, but CropperJS natively
+		// leaves the crop box's SCREEN pixels alone — that yields the
+		// disconcerting "image grows inside a static frame" effect. We
+		// want the crop box to follow the image (same natural-image
+		// footprint, visually growing/shrinking with the picture) so the
+		// user can keep zooming without their framing drifting.
+		//
+		// Approach: snapshot getData() (crop rect in natural-image px,
+		// independent of zoom) before zooming, then setData() after the
+		// zoom settles. CropperJS re-projects the saved natural rect at
+		// the new zoom level, so the crop box tracks the image 1:1.
+		_zoom_preserving_crop(fn) {
 			if (!this.cropper) return;
-			this.cropper.zoom(delta);
+			const saved = this.cropper.getData();
+			fn();
+			// The zoom action mutates container metrics synchronously;
+			// setData right after re-draws the crop box to match the
+			// saved natural rect at the new display scale.
+			this.cropper.setData(saved);
+		},
+		zoom_by(delta) {
+			this._zoom_preserving_crop(() => this.cropper.zoom(delta));
 		},
 		zoom_fit() {
 			if (!this.cropper) return;
+			// reset() resets both image position AND crop box — the
+			// explicit "Fit" action, closest to the initial mount state.
 			this.cropper.reset();
 		},
 		zoom_actual() {
-			if (!this.cropper) return;
-			this.cropper.zoomTo(1);
+			this._zoom_preserving_crop(() => this.cropper.zoomTo(1));
 		},
 
 		set_mode(mode) {
@@ -2341,12 +2363,25 @@ export default {
 			this.wm_dragging = false;
 		},
 		on_wrapper_wheel(e) {
-			if (this.interaction_mode !== "watermark") return;
-			if (this.wm_mode !== "Corner") return;
-			if (!this.wm_enabled || !this.wm_loaded) return;
-			const delta = e.deltaY > 0 ? -1 : 1;
-			this.wm_size = Math.max(5, Math.min(100, this.wm_size + delta));
-			this.wm_draw();
+			// Watermark Corner mode: wheel resizes the draggable logo
+			// (size %). Keep the original behaviour.
+			if (this.interaction_mode === "watermark"
+				&& this.wm_mode === "Corner"
+				&& this.wm_enabled
+				&& this.wm_loaded) {
+				const delta = e.deltaY > 0 ? -1 : 1;
+				this.wm_size = Math.max(5, Math.min(100, this.wm_size + delta));
+				this.wm_draw();
+				return;
+			}
+			// Crop mode (default): wheel zooms the stage. Delta matches
+			// CropperJS's wheelZoomRatio of 0.1, and we route through
+			// _zoom_preserving_crop so the crop box tracks the image
+			// — consistent with the +/- toolbar buttons.
+			if (this.cropper) {
+				const step = e.deltaY > 0 ? -0.1 : 0.1;
+				this._zoom_preserving_crop(() => this.cropper.zoom(step));
+			}
 		},
 		on_wrapper_touchstart(e) {
 			if (this.interaction_mode !== "watermark") return;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -119,9 +119,11 @@
 						@mousedown.stop="on_comment_mousedown($event, i)"
 						@touchstart.stop="on_comment_touchstart($event, i)"
 					>
-						<div class="comment-overlay-text" :style="comment_text_style(box)">
-							{{ box.text || __('(empty)') }}
-						</div>
+						<!-- Span instead of div so the text is truly inline and
+						     shrink-wraps to content. Must be on one line in the
+						     template too, otherwise white-space: pre-wrap would
+						     include the template's indentation whitespace. -->
+						<span class="comment-overlay-text" :style="comment_text_style(box)">{{ box.text || __('(empty)') }}</span>
 						<div
 							v-if="selected_comment_idx === i && selected_type === 'comment'"
 							class="comment-rotate-handle"
@@ -397,7 +399,7 @@
 									+ {{ __("Add") }}
 								</button>
 								<button
-									v-if="comment_presets && comment_presets.length"
+									v-if="effective_comment_presets.length"
 									type="button"
 									class="btn btn-xs btn-default"
 									@click="_toggle_preset_menu()"
@@ -406,7 +408,7 @@
 								</button>
 								<div v-if="preset_menu_open" class="comment-preset-menu">
 									<div
-										v-for="(p, pi) in comment_presets"
+										v-for="(p, pi) in effective_comment_presets"
 										:key="'preset-' + pi"
 										class="comment-preset-item"
 										@click="_insert_preset(p)"
@@ -523,10 +525,16 @@
 								</label>
 								<label class="comment-control">
 									<span>{{ __("Rotate °") }}</span>
-									<input type="number" class="wm-input comment-num-input"
+									<input type="number" class="wm-input comment-num-input scrubber-input"
 										min="-180" max="180" step="5"
 										:value="Math.round(box.rotation_deg || 0)"
+										:title="__('Type a value, or click & drag left/right to scrub.')"
 										@input="_update_comment(i, 'rotation_deg', parseFloat($event.target.value) || 0)"
+										@mousedown="_scrub_start($event, {
+											get: () => box.rotation_deg || 0,
+											set: (v) => _update_comment(i, 'rotation_deg', v),
+											step: 1, min: -180, max: 180,
+										})"
 									/>
 								</label>
 							</div>
@@ -754,6 +762,11 @@ export default {
 			selected_comment_idx: -1,
 			comment_dragging_idx: -1,
 			_comment_drag_start: null,
+			// Local override of the comment_presets prop. Props are one-way,
+			// so after "Save as Default" writes a new preset list on the
+			// server we mirror it here and read via `effective_comment_presets`
+			// so the Presets dropdown refreshes without re-opening the dialog.
+			local_comment_presets: null,
 			// Canvas data cache (image display rect in cropper wrapper)
 			// updated on cropper ready + crop event for overlay positioning.
 			// NB: no leading underscore — Vue 2 skips reactivity proxying for
@@ -1069,6 +1082,14 @@ export default {
 			if (this.local_padding_pct != null) return this.local_padding_pct;
 			const p = Number(this.remove_bg_padding_pct);
 			return Number.isFinite(p) ? p : 2;
+		},
+
+		// Preset list used by the Presets dropdown. Prefers the local copy
+		// set by "Save as Default" (so the dropdown refreshes live) over
+		// the one-way prop from the parent (which is frozen at dialog open).
+		effective_comment_presets() {
+			if (Array.isArray(this.local_comment_presets)) return this.local_comment_presets;
+			return this.comment_presets || [];
 		},
 
 		// Comment overlay sits on top of the image display area (NOT
@@ -1705,14 +1726,15 @@ export default {
 				callback: () => {
 					// Refresh the client-side settings cache used by item.js
 					// so the next time the uploader opens, Comments comes up
-					// with the new enabled state + preset list. Without this,
-					// the cache keeps serving the pre-save snapshot and the
-					// user sees the toggle revert on reopen — especially
-					// confusing when the preset list is empty but enabled.
+					// with the new enabled state + preset list.
 					if (frappe._image_processing_settings_cache) {
 						frappe._image_processing_settings_cache.default_comments_enabled = !!enabled_snapshot;
 						frappe._image_processing_settings_cache.comment_presets = presets_snapshot;
 					}
+					// Also mirror into our local override so the Presets
+					// dropdown in THIS dialog picks up the change without
+					// reopening — the `comment_presets` prop is one-way.
+					this.local_comment_presets = presets_snapshot.map((p) => ({ ...p }));
 					frappe.show_alert({
 						message: __("Saved {0} comments as default", [presets_snapshot.length]),
 						indicator: "green",
@@ -1722,11 +1744,12 @@ export default {
 		},
 
 		// Reset the panel — replace box list with the current
-		// comment_presets prop (which is the singleton's saved list).
+		// effective_comment_presets (local override if any, else prop).
 		// Also flips the enable toggle back to the saved default.
 		_reset_comments_panel() {
-			this.comment_boxes = Array.isArray(this.comment_presets)
-				? this.comment_presets.map((p) => ({ ...p }))
+			const src = this.effective_comment_presets;
+			this.comment_boxes = Array.isArray(src)
+				? src.map((p) => ({ ...p }))
 				: [];
 			this.selected_comment_idx = -1;
 			this.comments_enabled = !!this.comments_default_enabled;
@@ -1786,6 +1809,39 @@ export default {
 			if (!current) return;
 			this.$set(this.comment_boxes, i, { ...current, [field]: value });
 		},
+
+		// Figma/Blender-style scrubber: click a number input and drag
+		// left/right (without releasing) to change its value. Releasing
+		// the drag still lets the user type normally. One px = one step.
+		_scrub_start(e, opts) {
+			if (e.button !== 0) return;
+			const startX = e.clientX;
+			const startV = Number(opts.get()) || 0;
+			let moved = false;
+			const onMove = (me) => {
+				const dx = me.clientX - startX;
+				if (!moved && Math.abs(dx) < 3) return;
+				moved = true;
+				// Prevent text selection + browser drag while scrubbing
+				me.preventDefault();
+				let v = startV + dx * (opts.step || 1);
+				if (opts.min != null) v = Math.max(opts.min, v);
+				if (opts.max != null) v = Math.min(opts.max, v);
+				opts.set(Math.round(v));
+				document.body.style.cursor = "ew-resize";
+			};
+			const onUp = () => {
+				document.removeEventListener("mousemove", onMove);
+				document.removeEventListener("mouseup", onUp);
+				document.body.style.cursor = "";
+				// If the user actually dragged, blur the input so the
+				// focus ring doesn't linger — feels more like a handle,
+				// less like an edit session.
+				if (moved) e.target.blur();
+			};
+			document.addEventListener("mousemove", onMove);
+			document.addEventListener("mouseup", onUp);
+		},
 		_delete_comment(i) {
 			this.comment_boxes.splice(i, 1);
 		},
@@ -1812,79 +1868,87 @@ export default {
 		// Paint all enabled comment boxes onto the cropped canvas. Called
 		// after watermark compositing, before aspect normalize, so boxes
 		// stay attached to content (not Contain-padded fill strips).
-		// Mirrors the server-side _apply_comment_boxes in item_image_batch.py.
+		// Mirrors server-side _apply_comment_boxes exactly. Canvas passed
+		// in is the CROPPED image (cropper.getCroppedCanvas()), so its
+		// width/height already equal the natural crop size — the same
+		// tensor the server works on post-crop. That means we can use
+		// the server's formulas as-is (w/h = canvas size), with a single
+		// extra step: subtract crop_x/crop_y when projecting the box's
+		// full-image-relative position to the cropped canvas origin.
 		_composite_comments_on_canvas(canvas, ctx) {
 			if (!this.comment_boxes || this.comment_boxes.length === 0) return;
+			const image_data = this.cropper && this.cropper.getImageData();
+			const crop_data = this.cropper && this.cropper.getData();
+			if (!image_data || !crop_data) return;
 			const w = canvas.width;
 			const h = canvas.height;
+			const full_w = image_data.naturalWidth;
+			const full_h = image_data.naturalHeight;
+
 			for (const box of this.comment_boxes) {
 				if (!box.text) continue;
+				// Font size formula = server's: h (cropped image height) × pct.
 				const font_size_px = Math.max(1, Math.round(h * (box.font_size_pct || 5.0) / 100));
 				const family = box.font_family || "Arial";
 				const weight = box.font_weight === "Bold" ? "bold" : "normal";
 				const style = box.font_style === "Italic" ? "italic" : "normal";
 				ctx.font = `${style} ${weight} ${font_size_px}px "${family}", sans-serif`;
 				ctx.fillStyle = box.color || "#000000";
+				ctx.textBaseline = "top";
 
-				const cx = w * (box.position_x_pct || 50) / 100;
-				const cy = h * (box.position_y_pct || 50) / 100;
-				const box_w_px = w * (box.width_pct || 40) / 100;
+				// Box position is % of the FULL image (not the crop). Project
+				// to the cropped canvas by subtracting crop_x/crop_y.
+				const width_pct = box.width_pct || 40;
+				const height_pct = box.height_pct || 10;
+				const box_left = full_w * ((box.position_x_pct || 50) - width_pct / 2) / 100 - crop_data.x;
+				const box_top = full_h * ((box.position_y_pct || 50) - height_pct / 2) / 100 - crop_data.y;
+
+				// Padding formula = server's (pad_x = w*4/1000 floor 4,
+				// pad_y = h*2/1000 floor 2). But w/h on the server are the
+				// CROPPED image's width/height, which equals our canvas
+				// size here — so use w/h directly.
+				const pad_x = Math.max(4, w * 4 / 1000);
+				const pad_y = Math.max(2, h * 2 / 1000);
+
 				const rotation_deg = box.rotation_deg || 0;
+				const lines = String(box.text || "").split("\n");
+				if (!lines.length) continue;
 
-				// Simple greedy word-wrap (same intent as _wrap_to_width on server)
-				const lines = this._wrap_text_to_width(
-					String(box.text || ""), box_w_px, ctx
-				);
+				// PIL text uses ascent-to-descent metrics; getbbox gives
+				// tight bounds. Canvas fillText with textBaseline: "top"
+				// uses the font-metrics top, which includes the ascent.
+				// Close enough for preview — visual offset within ±1 px.
 				const line_h = font_size_px * 1.2;
-				const total_h = lines.length * line_h;
 
-				// Rotate around box center (cx, cy). Matches CSS transform-origin 50% 50%
-				// on the overlay box and PIL's rotate(-angle, expand=True) + alpha_composite
-				// which keeps text centered on (cx, cy) after rotation.
+				ctx.save();
+				// Rotate around box top-left — matches server rotate(center=(0,0))
+				// + paste at box origin.
 				const needs_rotate = Math.abs(rotation_deg) > 0.001;
 				if (needs_rotate) {
-					ctx.save();
-					ctx.translate(cx, cy);
+					ctx.translate(box_left, box_top);
 					ctx.rotate((rotation_deg * Math.PI) / 180);
-					ctx.translate(-cx, -cy);
+					ctx.translate(-box_left, -box_top);
 				}
 
-				let y_cursor = cy - total_h / 2 + line_h * 0.75;
+				const max_line_w = lines.reduce(
+					(m, ln) => Math.max(m, ctx.measureText(ln || " ").width), 0
+				);
+				let y_cursor = box_top + pad_y;
 				for (const line of lines) {
-					const line_w = ctx.measureText(line).width;
+					const line_w = ctx.measureText(line || " ").width;
 					let x;
-					if (box.align === "Left") x = cx - box_w_px / 2;
-					else if (box.align === "Right") x = cx + box_w_px / 2 - line_w;
-					else x = cx - line_w / 2;
+					if (box.align === "Right") {
+						x = box_left + pad_x + max_line_w - line_w;
+					} else if (box.align === "Center") {
+						x = box_left + pad_x + (max_line_w - line_w) / 2;
+					} else {
+						x = box_left + pad_x;
+					}
 					ctx.fillText(line, x, y_cursor);
 					y_cursor += line_h;
 				}
-
-				if (needs_rotate) {
-					ctx.restore();
-				}
+				ctx.restore();
 			}
-		},
-
-		_wrap_text_to_width(text, max_width_px, ctx) {
-			if (!text) return [];
-			const out = [];
-			for (const paragraph of text.split("\n")) {
-				if (!paragraph) { out.push(""); continue; }
-				const words = paragraph.split(" ");
-				let line = "";
-				for (const word of words) {
-					const candidate = line ? `${line} ${word}` : word;
-					if (ctx.measureText(candidate).width <= max_width_px || !line) {
-						line = candidate;
-					} else {
-						out.push(line);
-						line = word;
-					}
-				}
-				if (line) out.push(line);
-			}
-			return out;
 		},
 
 		// ── Live preview (new 2026-04) ──
@@ -1996,12 +2060,6 @@ export default {
 			const scale_y = ch / crop_h;
 
 			if (this.wm_mode === "Tiled") {
-				// Tile size & spacing are a % of the source image's natural
-				// width, then scaled into output-canvas pixels via scale_x.
-				// Matches the overlay which anchors to getCanvasData (=
-				// naturalWidth × zoom) → WYSIWYG. Crop size and padding
-				// don't change tile dimensions; they just open a different
-				// window onto the same pattern.
 				const tile_w_natural = (this.wm_tile_size / 100) * full_w;
 				const tile_h_natural = tile_w_natural * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
 				const spacing_natural = (this.wm_tile_spacing / 100) * full_w;
@@ -2010,10 +2068,6 @@ export default {
 				const step_x = tile_w + spacing_natural * scale_x;
 				const step_y = tile_h + spacing_natural * scale_y;
 				const angle = (this.wm_tile_rotation * Math.PI) / 180;
-				// Pattern origin = center of the full source image projected
-				// into output coords. Keeps tile phase stable across crops
-				// (move the crop box → same tile positions relative to the
-				// image, not re-centered to the crop).
 				const origin_x = (full_w / 2 - crop_x) * scale_x;
 				const origin_y = (full_h / 2 - crop_y) * scale_y;
 				ctx.save();
@@ -2027,9 +2081,13 @@ export default {
 					Math.max(origin_y, ch - origin_y) ** 2
 				);
 				const reach = max_dist + Math.max(tile_w, tile_h);
-				for (let y = -reach; y < reach; y += step_y) {
-					for (let x = -reach; x < reach; x += step_x) {
-						ctx.drawImage(this.wm_img, x, y, tile_w, tile_h);
+				// Step-aligned loop: matches the overlay so tiles land at
+				// identical (origin + k × step) positions in both canvases.
+				const kx = Math.ceil(reach / step_x);
+				const ky = Math.ceil(reach / step_y);
+				for (let j = -ky; j <= ky; j++) {
+					for (let i = -kx; i <= kx; i++) {
+						ctx.drawImage(this.wm_img, i * step_x, j * step_y, tile_w, tile_h);
 					}
 				}
 				ctx.restore();
@@ -2261,16 +2319,22 @@ export default {
 			ctx.rotate(angle);
 
 			// Reach from the image center out to the farthest container
-			// corner, so tiles cover the whole overlay (crop box can sit
-			// anywhere and still land on watermarked pixels).
+			// corner, then round up to a STEP multiple so the first tile
+			// always lands at `origin + k × step` (k integer). Without
+			// this, the loop would start at `-reach` (whatever reach
+			// happens to be) and the tile phase would drift every time
+			// zoom changed step size — visible as the pattern shifting
+			// sideways on +/- even though the image didn't move.
 			const max_dist = Math.sqrt(
 				Math.max(ox, container_w - ox) ** 2 +
 				Math.max(oy, container_h - oy) ** 2
 			);
 			const reach = max_dist + Math.max(tile_w, tile_h);
-			for (let y = -reach; y < reach; y += step_y) {
-				for (let x = -reach; x < reach; x += step_x) {
-					ctx.drawImage(this.wm_img, x, y, tile_w, tile_h);
+			const kx = Math.ceil(reach / step_x);
+			const ky = Math.ceil(reach / step_y);
+			for (let j = -ky; j <= ky; j++) {
+				for (let i = -kx; i <= kx; i++) {
+					ctx.drawImage(this.wm_img, i * step_x, j * step_y, tile_w, tile_h);
 				}
 			}
 			ctx.restore();
@@ -3619,6 +3683,15 @@ img {
 	border-color: #3b82f6 !important;
 	box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
+/* Scrubber hint: horizontal-resize cursor on hover so users know the
+   input is draggable (Figma/Blender convention). Value stays editable
+   by tab/focus + type; drag is an extra interaction, not a replacement. */
+.scrubber-input {
+	cursor: ew-resize;
+}
+.scrubber-input:focus {
+	cursor: text;
+}
 .comments-actions {
 	display: flex;
 	gap: 6px;
@@ -3659,19 +3732,24 @@ img {
    transparent to events and falls through to CropperJS. */
 .comment-overlay {
 	pointer-events: none;
+	/* Sit above the watermark canvas (z-index: 5) and CropperJS's crop
+	   chrome (no explicit z-index, so still under 10). */
+	z-index: 10;
+	position: absolute;
 }
 .comment-overlay-box {
 	position: absolute;
 	border: 1px dashed rgba(16, 185, 129, 0.65);
 	box-sizing: border-box;
 	user-select: none;
-	display: flex;
-	align-items: flex-start;   /* text flows from top of the box, not centered */
-	justify-content: center;
-	overflow: hidden;
 	background: rgba(16, 185, 129, 0.04);
 	pointer-events: auto;
 	cursor: move;
+	/* overflow: visible — text can extend past the box edges, matching
+	   Figma/Canva behaviour. The box is a positioning target, not a clip
+	   mask. If the user makes the box smaller than the text, the text
+	   keeps rendering outside. */
+	overflow: visible;
 }
 .comment-overlay-box:hover {
 	background: rgba(16, 185, 129, 0.1);
@@ -3685,13 +3763,21 @@ img {
 	opacity: 0.85;
 }
 .comment-overlay-text {
-	width: 100%;
+	position: absolute;
+	left: 0;
+	top: 0;
 	padding: 2px 4px;
+	box-sizing: border-box;
 	line-height: 1.15;
-	word-break: break-word;
+	/* pre-wrap so the user's own \n characters (Enter in the textarea)
+	   wrap, but runs of plain spaces still collapse. The template keeps
+	   {{ box.text }} on one line so none of the template's indentation
+	   whitespace leaks into the rendered content. */
 	white-space: pre-wrap;
-	overflow: hidden;
-	text-overflow: clip;
+	/* Halo so dark text reads on dark product, light text on light. */
+	text-shadow:
+		0 0 2px rgba(255, 255, 255, 0.9),
+		0 0 4px rgba(255, 255, 255, 0.7);
 }
 .comment-rotate-handle {
 	position: absolute;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -380,19 +380,23 @@
 									@input="wm_size = parseFloat($event.target.value)" />
 								<span class="wm-slider-value">{{ Math.round(wm_size) }}%</span>
 							</div>
+							<!-- Position is a free number input (no clamp):
+							     values <0 or >100 place the watermark outside
+							     the image. Users mostly position via drag on
+							     the canvas; the input is for precise entry. -->
 							<div class="wm-slider-row">
 								<label class="wm-slider-label">{{ __("Position X") }}</label>
-								<input type="range" class="wm-slider" min="0" max="100"
-									:value="wm_pos_x"
-									@input="wm_pos_x = parseFloat($event.target.value)" />
-								<span class="wm-slider-value">{{ Math.round(wm_pos_x) }}%</span>
+								<input type="number" class="wm-input wm-num-input" step="1"
+									:value="Math.round(wm_pos_x)"
+									@input="wm_pos_x = parseFloat($event.target.value) || 0" />
+								<span class="wm-slider-value">%</span>
 							</div>
 							<div class="wm-slider-row">
 								<label class="wm-slider-label">{{ __("Position Y") }}</label>
-								<input type="range" class="wm-slider" min="0" max="100"
-									:value="wm_pos_y"
-									@input="wm_pos_y = parseFloat($event.target.value)" />
-								<span class="wm-slider-value">{{ Math.round(wm_pos_y) }}%</span>
+								<input type="number" class="wm-input wm-num-input" step="1"
+									:value="Math.round(wm_pos_y)"
+									@input="wm_pos_y = parseFloat($event.target.value) || 0" />
+								<span class="wm-slider-value">%</span>
 							</div>
 							<div class="wm-slider-row">
 								<label class="wm-slider-label">{{ __("Rotation") }}</label>
@@ -533,18 +537,19 @@
 										@click="_update_comment(i, 'align', a)"
 									>{{ a.charAt(0) }}</button>
 								</div>
+								<!-- No min/max on position: boxes can sit outside
+								     the image (negative or >100). Same freedom as
+								     the crop rect. -->
 								<label class="comment-control">
 									<span>X%</span>
-									<input type="number" class="wm-input comment-num-input"
-										min="0" max="100" step="1"
+									<input type="number" class="wm-input comment-num-input" step="1"
 										:value="Math.round(box.position_x_pct)"
 										@input="_update_comment(i, 'position_x_pct', parseFloat($event.target.value) || 0)"
 									/>
 								</label>
 								<label class="comment-control">
 									<span>Y%</span>
-									<input type="number" class="wm-input comment-num-input"
-										min="0" max="100" step="1"
+									<input type="number" class="wm-input comment-num-input" step="1"
 										:value="Math.round(box.position_y_pct)"
 										@input="_update_comment(i, 'position_y_pct', parseFloat($event.target.value) || 0)"
 									/>
@@ -1646,8 +1651,9 @@ export default {
 			const dy = e.clientY - start.clientY;
 			const dxPct = (dx / cd.width) * 100;
 			const dyPct = (dy / cd.height) * 100;
-			const newX = Math.max(0, Math.min(100, start.origXPct + dxPct));
-			const newY = Math.max(0, Math.min(100, start.origYPct + dyPct));
+			// No clamp — boxes can be dragged outside the image.
+			const newX = start.origXPct + dxPct;
+			const newY = start.origYPct + dyPct;
 			this.$set(this.comment_boxes, i, {
 				...box,
 				position_x_pct: newX,
@@ -2401,8 +2407,10 @@ export default {
 			const mx = e.clientX - rect.left;
 			const my = e.clientY - rect.top;
 			const cd = this.cropper.getCanvasData();
-			this.wm_pos_x = Math.max(0, Math.min(100, ((mx - this.wm_drag_offset_x - cd.left) / cd.width) * 100));
-			this.wm_pos_y = Math.max(0, Math.min(100, ((my - this.wm_drag_offset_y - cd.top) / cd.height) * 100));
+			// No clamp — watermark can sit outside the image (same model
+			// as the crop box, which also allows negative coords).
+			this.wm_pos_x = ((mx - this.wm_drag_offset_x - cd.left) / cd.width) * 100;
+			this.wm_pos_y = ((my - this.wm_drag_offset_y - cd.top) / cd.height) * 100;
 			this.wm_draw();
 		},
 		on_wrapper_mouseup() {
@@ -2456,20 +2464,20 @@ export default {
 			const mx = touch.clientX - rect.left;
 			const my = touch.clientY - rect.top;
 			const cd = this.cropper.getCanvasData();
-			this.wm_pos_x = Math.max(0, Math.min(100, ((mx - this.wm_drag_offset_x - cd.left) / cd.width) * 100));
-			this.wm_pos_y = Math.max(0, Math.min(100, ((my - this.wm_drag_offset_y - cd.top) / cd.height) * 100));
+			this.wm_pos_x = ((mx - this.wm_drag_offset_x - cd.left) / cd.width) * 100;
+			this.wm_pos_y = ((my - this.wm_drag_offset_y - cd.top) / cd.height) * 100;
 			this.wm_draw();
 		},
 
 		// Watermark control panel methods
 		wm_set_pos_x(val) {
 			if (isNaN(val)) return;
-			this.wm_pos_x = Math.max(0, Math.min(100, val));
+			this.wm_pos_x = val;
 			this.wm_draw();
 		},
 		wm_set_pos_y(val) {
 			if (isNaN(val)) return;
-			this.wm_pos_y = Math.max(0, Math.min(100, val));
+			this.wm_pos_y = val;
 			this.wm_draw();
 		},
 		wm_set_size(val) {
@@ -2899,6 +2907,22 @@ img {
 	font-variant-numeric: tabular-nums;
 	font-weight: 500;
 }
+.wm-slider-row .wm-num-input {
+	flex: 1;
+	min-width: 0;
+	max-width: 120px;
+	height: 28px;
+	padding: 2px 8px;
+	font-size: 14px;
+	border: 1px solid #dcdfe6;
+	border-radius: 4px;
+}
+.wm-slider-row .wm-num-input::-webkit-inner-spin-button,
+.wm-slider-row .wm-num-input::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+.wm-slider-row .wm-num-input { -moz-appearance: textfield; }
 
 /* ── Mobile: stack left + right columns ──
    At ≤900px the outer grid collapses to one column. Cropper keeps

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -151,22 +151,6 @@
 				</div>
 			</div>
 
-			<!-- Bottom action row: Back / Crop -->
-			<div class="image-cropper-actions" ref="actions">
-				<div><!-- spacer for flex layout; no left actions --></div>
-				<div>
-					<button
-						class="btn btn-sm margin-right"
-						@click="$emit('toggle_image_cropper')"
-						v-if="fixed_aspect_ratio == null"
-					>
-						{{ __("Back") }}
-					</button>
-					<button class="btn btn-primary btn-sm" :disabled="bg_processing" @click="crop_image">
-						{{ __("Crop") }}
-					</button>
-				</div>
-			</div>
 		</div>
 
 		<!-- RIGHT COLUMN: tabbed feature panel -->
@@ -633,6 +617,25 @@
 						</div>
 					</div>
 				</div>
+			</div>
+		</div>
+		<!-- Bottom action row spans both columns so Back / Crop sit in the
+		     same bottom-right corner the Upload button occupies on Step 1
+		     and Step 3 — consistent toolbar across the whole 3-step flow. -->
+		<div class="image-cropper-actions image-cropper-actions-bottom" ref="actions">
+			<div>
+				<button
+					class="btn btn-sm"
+					@click="$emit('toggle_image_cropper')"
+					v-if="fixed_aspect_ratio == null"
+				>
+					{{ __("Back") }}
+				</button>
+			</div>
+			<div>
+				<button class="btn btn-primary btn-sm" :disabled="bg_processing" @click="crop_image">
+					{{ __("Crop") }}
+				</button>
 			</div>
 		</div>
 	</div>
@@ -2230,9 +2233,13 @@ export default {
 .cropper-grid {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) minmax(320px, 400px);
+	grid-template-rows: 1fr auto;
 	gap: 16px;
 	align-items: stretch;
 	min-height: 0;
+}
+.cropper-grid .image-cropper-actions-bottom {
+	grid-column: 1 / -1;
 }
 .cropper-left-col {
 	display: flex;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1,8 +1,10 @@
 <template>
 	<div>
-		<!-- Interaction-mode switcher: Corner mode only (Tiled has no drag target). -->
+		<!-- Interaction-mode switcher: shown when multiple drag targets exist
+		     (watermark Corner OR comments enabled). Lets the user pick which
+		     overlay they're dragging. -->
 		<div
-			v-if="show_watermark && wm_enabled && wm_loaded && wm_mode === 'Corner'"
+			v-if="(show_watermark && wm_enabled && wm_loaded && wm_mode === 'Corner') || (show_comments && comments_enabled && comment_boxes.length > 0)"
 			class="interaction-switcher"
 		>
 			<span class="interaction-switcher-label">{{ __("Drag on image") }}</span>
@@ -19,6 +21,7 @@
 					{{ __("Crop box") }}
 				</button>
 				<button
+					v-if="show_watermark && wm_enabled && wm_loaded && wm_mode === 'Corner'"
 					class="segmented-tab"
 					:class="{ active: interaction_mode === 'watermark' }"
 					role="tab"
@@ -29,6 +32,20 @@
 					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
 					{{ __("Watermark") }}
 				</button>
+				<button
+					v-if="show_comments && comments_enabled && comment_boxes.length > 0"
+					class="segmented-tab"
+					:class="{ active: interaction_mode === 'comment' }"
+					role="tab"
+					:aria-selected="interaction_mode === 'comment'"
+					:title="__('Drag to move text comments')"
+					@click="set_mode('comment')"
+				>
+					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+					</svg>
+					{{ __("Comment") }}
+				</button>
 			</div>
 		</div>
 
@@ -37,6 +54,7 @@
 			ref="wrapper"
 			:class="{
 				'wm-mode': interaction_mode === 'watermark' && wm_mode === 'Corner',
+				'comment-mode': interaction_mode === 'comment',
 				'bg-processing': bg_processing,
 			}"
 			@mousedown="on_wrapper_mousedown"
@@ -50,6 +68,32 @@
 				class="watermark-overlay-canvas"
 				:style="{ pointerEvents: (interaction_mode === 'watermark' && wm_mode === 'Corner') ? 'auto' : 'none' }"
 			></canvas>
+			<!-- Comment overlay: DOM boxes drawn on top of the image so user
+			     can see text positioning + drag them. Uses CropperJS image
+			     data to convert percentages → screen pixels. -->
+			<div
+				v-if="show_comments && comments_enabled"
+				class="comment-overlay"
+				:style="comment_overlay_style"
+			>
+				<div
+					v-for="(box, i) in comment_boxes"
+					:key="'overlay-box-' + i"
+					class="comment-overlay-box"
+					:class="{
+						selected: selected_comment_idx === i,
+						dragging: comment_dragging_idx === i,
+					}"
+					:style="comment_box_style(box)"
+					:data-box-idx="i"
+					@mousedown.stop="on_comment_mousedown($event, i)"
+					@touchstart.stop="on_comment_touchstart($event, i)"
+				>
+					<div class="comment-overlay-text" :style="comment_text_style(box)">
+						{{ box.text || __('(empty)') }}
+					</div>
+				</div>
+			</div>
 			<div v-if="bg_processing" class="cropper-loading-overlay">
 				<div class="cropper-spinner"></div>
 				<div class="cropper-loading-text">{{ __("Removing background...") }}</div>
@@ -125,18 +169,27 @@
 					</div>
 				</div>
 				<div class="resize-misc-row">
-					<label class="resize-inline-field">
-						<span>{{ __("Fill") }}</span>
+					<label class="resize-inline-toggle">
+						<input type="checkbox" v-model="resize_flatten_rgb" />
+						<span>{{ __("Solid background") }}</span>
+					</label>
+					<label
+						v-if="resize_flatten_rgb"
+						class="resize-inline-field"
+					>
+						<span>{{ __("Background color") }}</span>
 						<input
 							type="color"
 							class="resize-color"
 							v-model="resize_fill_color"
 						/>
 					</label>
-					<label class="resize-inline-toggle">
-						<input type="checkbox" v-model="resize_flatten_rgb" />
-						<span>{{ __("Flatten RGB") }}</span>
-					</label>
+					<span
+						v-if="!resize_flatten_rgb"
+						class="resize-hint"
+					>
+						{{ __("Transparent background (PNG)") }}
+					</span>
 				</div>
 			</div>
 
@@ -163,6 +216,8 @@
 					v-for="(box, i) in comment_boxes"
 					:key="'box-' + i"
 					class="comment-entry"
+					:class="{ 'comment-entry-selected': selected_comment_idx === i }"
+					@click="selected_comment_idx = i"
 				>
 					<div class="comment-entry-header">
 						<span class="comment-entry-idx">#{{ i + 1 }}</span>
@@ -177,10 +232,21 @@
 							type="button"
 							class="btn btn-xs btn-danger comment-delete"
 							:title="__('Delete comment')"
-							@click="_delete_comment(i)"
+							@click.stop="_delete_comment(i)"
 						>×</button>
 					</div>
+
+					<!-- Row 1: Font family + Size + style toggles -->
 					<div class="comment-entry-controls">
+						<label class="comment-control comment-control-wide">
+							<span>{{ __("Font") }}</span>
+							<select class="wm-input comment-font-select"
+								:value="box.font_family"
+								@change="_update_comment(i, 'font_family', $event.target.value)"
+							>
+								<option v-for="f in comment_font_families" :key="f" :value="f">{{ f }}</option>
+							</select>
+						</label>
 						<label class="comment-control">
 							<span>{{ __("Size %") }}</span>
 							<input type="number" class="wm-input comment-num-input"
@@ -189,6 +255,40 @@
 								@input="_update_comment(i, 'font_size_pct', parseFloat($event.target.value) || 5.0)"
 							/>
 						</label>
+						<button
+							type="button"
+							class="comment-style-btn"
+							:class="{ active: box.font_weight === 'Bold' }"
+							:title="__('Bold')"
+							@click="_update_comment(i, 'font_weight', box.font_weight === 'Bold' ? 'Normal' : 'Bold')"
+						><strong>B</strong></button>
+						<button
+							type="button"
+							class="comment-style-btn"
+							:class="{ active: box.font_style === 'Italic' }"
+							:title="__('Italic')"
+							@click="_update_comment(i, 'font_style', box.font_style === 'Italic' ? 'Normal' : 'Italic')"
+						><em>I</em></button>
+						<input type="color" class="comment-color-input"
+							:title="__('Text color')"
+							:value="box.color"
+							@input="_update_comment(i, 'color', $event.target.value)"
+						/>
+					</div>
+
+					<!-- Row 2: Alignment + position -->
+					<div class="comment-entry-controls">
+						<div class="comment-align-group">
+							<button
+								v-for="a in ['Left', 'Center', 'Right']"
+								:key="'align-' + a"
+								type="button"
+								class="comment-align-btn"
+								:class="{ active: box.align === a }"
+								:title="__(a)"
+								@click="_update_comment(i, 'align', a)"
+							>{{ a.charAt(0) }}</button>
+						</div>
 						<label class="comment-control">
 							<span>X%</span>
 							<input type="number" class="wm-input comment-num-input"
@@ -206,16 +306,11 @@
 							/>
 						</label>
 						<label class="comment-control">
-							<input type="checkbox"
-								:checked="box.font_weight === 'Bold'"
-								@change="_update_comment(i, 'font_weight', $event.target.checked ? 'Bold' : 'Normal')"
-							/>
-							<span>B</span>
-						</label>
-						<label class="comment-control">
-							<input type="color"
-								:value="box.color"
-								@input="_update_comment(i, 'color', $event.target.value)"
+							<span>W%</span>
+							<input type="number" class="wm-input comment-num-input"
+								min="5" max="100" step="1"
+								:value="Math.round(box.width_pct)"
+								@input="_update_comment(i, 'width_pct', parseFloat($event.target.value) || 5)"
 							/>
 						</label>
 					</div>
@@ -243,6 +338,15 @@
 							{{ p.text || __("(no text)") }}
 						</div>
 					</div>
+				</div>
+
+				<div class="wm-panel-actions">
+					<button class="btn btn-xs btn-default" @click="_reset_comments_to_defaults">
+						{{ __("Reset") }}
+					</button>
+					<button class="btn btn-xs btn-primary-light" @click="_save_comment_defaults">
+						{{ __("Save Style as Default") }}
+					</button>
 				</div>
 			</div>
 
@@ -561,13 +665,22 @@ export default {
 			// change so the user sees exactly what Crop will produce.
 			preview_dims: null,
 			_preview_debounce: null,
-			// Comments (new 2026-04) — simple list baked into the final
-			// Canvas composite. No drag UI here; edits via textarea + number
-			// inputs. For the full drag/resize experience, use the Item
-			// Image Batch.
+			// Comments (new 2026-04) — list of text overlays baked into
+			// the final Canvas composite. Overlay DOM boxes on top of the
+			// cropper image for drag interaction.
 			comments_enabled: false,
 			comment_boxes: [],
 			preset_menu_open: false,
+			selected_comment_idx: -1,
+			comment_dragging_idx: -1,
+			_comment_drag_start: null,
+			// Canvas data cache (image display rect in cropper wrapper)
+			// updated on cropper ready + crop event for overlay positioning.
+			_canvas_data: null,
+			comment_font_families: [
+				"Arial", "Helvetica", "Times New Roman",
+				"Courier New", "Georgia", "Verdana",
+			],
 		};
 	},
 	watch: {
@@ -664,6 +777,19 @@ export default {
 		document.addEventListener("touchmove", this._on_touchmove, { passive: false });
 		document.addEventListener("touchend", this._on_touchend);
 
+		// Global listeners for comment drag (new 2026-04)
+		this._on_comment_mm = this._on_comment_mousemove.bind(this);
+		this._on_comment_mu = this._on_comment_mouseup.bind(this);
+		document.addEventListener("mousemove", this._on_comment_mm);
+		document.addEventListener("mouseup", this._on_comment_mu);
+		document.addEventListener("touchmove", (e) => {
+			if (this.comment_dragging_idx < 0) return;
+			const t = e.touches[0];
+			this._on_comment_mousemove({ clientX: t.clientX, clientY: t.clientY });
+			e.preventDefault();
+		}, { passive: false });
+		document.addEventListener("touchend", this._on_comment_mu);
+
 		// When the viewport or the modal itself resizes, the CropperJS canvas
 		// re-layouts automatically via its built-in listener, but our watermark
 		// overlay canvas sits on top and needs to be resized + redrawn manually.
@@ -708,6 +834,8 @@ export default {
 	beforeDestroy() {
 		document.removeEventListener("mousemove", this._on_mousemove);
 		document.removeEventListener("mouseup", this._on_mouseup);
+		if (this._on_comment_mm) document.removeEventListener("mousemove", this._on_comment_mm);
+		if (this._on_comment_mu) document.removeEventListener("mouseup", this._on_comment_mu);
 		document.removeEventListener("touchmove", this._on_touchmove);
 		document.removeEventListener("touchend", this._on_touchend);
 		window.removeEventListener("resize", this._on_window_resize);
@@ -732,6 +860,24 @@ export default {
 			if (this.local_padding_pct != null) return this.local_padding_pct;
 			const p = Number(this.remove_bg_padding_pct);
 			return Number.isFinite(p) ? p : 2;
+		},
+
+		// Comment overlay sits on top of the image display area (NOT
+		// the cropper wrapper as a whole). Position it via the cropper's
+		// getCanvasData() output so it tracks zoom + pan.
+		comment_overlay_style() {
+			const cd = this._canvas_data;
+			if (!cd) return { display: "none" };
+			return {
+				position: "absolute",
+				left: cd.left + "px",
+				top: cd.top + "px",
+				width: cd.width + "px",
+				height: cd.height + "px",
+				// pointerEvents only active when user is in comment mode,
+				// so watermark + crop drag still work from the same pixels.
+				pointerEvents: this.interaction_mode === "comment" ? "auto" : "none",
+			};
 		},
 	},
 	methods: {
@@ -774,6 +920,7 @@ export default {
 						if (this.wm_enabled && this.wm_loaded) {
 							this.$nextTick(() => this.wm_resize_canvas());
 						}
+						this._update_canvas_data();
 						// Initial preview render once cropper is ready
 						this.$nextTick(() => this._schedule_preview_update());
 					},
@@ -781,6 +928,7 @@ export default {
 						if (this.wm_enabled && this.wm_loaded) {
 							this.$nextTick(() => this.wm_draw());
 						}
+						this._update_canvas_data();
 						// Preview follows the crop box — user dragging
 						// the frame updates the preview live (debounced).
 						this._schedule_preview_update();
@@ -1068,6 +1216,149 @@ export default {
 		},
 
 		// ── Comments (new 2026-04) ──
+		// Per-box style computations for the DOM overlay on the image.
+		comment_box_style(box) {
+			// Percentage-based position + size. Absolute inside the
+			// .comment-overlay container which is already sized to match
+			// the cropper image display rect.
+			const leftPct = (box.position_x_pct || 50) - (box.width_pct || 40) / 2;
+			const topPct = (box.position_y_pct || 50) - (box.height_pct || 10) / 2;
+			return {
+				position: "absolute",
+				left: leftPct + "%",
+				top: topPct + "%",
+				width: (box.width_pct || 40) + "%",
+				height: (box.height_pct || 10) + "%",
+			};
+		},
+		comment_text_style(box) {
+			const cd = this._canvas_data;
+			// Compute px font size from the displayed image height, not
+			// the natural size (so on-screen text matches what user sees
+			// in the preview).
+			const displayH = (cd && cd.height) ? cd.height : 200;
+			const fontPx = Math.max(6, Math.round(displayH * (box.font_size_pct || 5.0) / 100));
+			return {
+				fontFamily: `"${box.font_family || "Arial"}", sans-serif`,
+				fontSize: fontPx + "px",
+				fontWeight: box.font_weight === "Bold" ? "700" : "400",
+				fontStyle: box.font_style === "Italic" ? "italic" : "normal",
+				color: box.color || "#000000",
+				textAlign: (box.align || "Center").toLowerCase(),
+			};
+		},
+
+		// Refresh canvas data cache so overlay positions track cropper
+		// zoom/pan. Called from cropper ready + crop events.
+		_update_canvas_data() {
+			if (!this.cropper) return;
+			try {
+				this._canvas_data = this.cropper.getCanvasData();
+			} catch (e) {
+				this._canvas_data = null;
+			}
+		},
+
+		// ── Comment drag handlers ──
+		on_comment_mousedown(e, i) {
+			if (this.interaction_mode !== "comment") return;
+			this.selected_comment_idx = i;
+			this.comment_dragging_idx = i;
+			const box = this.comment_boxes[i];
+			this._comment_drag_start = {
+				clientX: e.clientX,
+				clientY: e.clientY,
+				origXPct: box.position_x_pct,
+				origYPct: box.position_y_pct,
+			};
+			e.preventDefault();
+		},
+		on_comment_touchstart(e, i) {
+			if (this.interaction_mode !== "comment") return;
+			const t = e.touches[0];
+			this.selected_comment_idx = i;
+			this.comment_dragging_idx = i;
+			const box = this.comment_boxes[i];
+			this._comment_drag_start = {
+				clientX: t.clientX,
+				clientY: t.clientY,
+				origXPct: box.position_x_pct,
+				origYPct: box.position_y_pct,
+			};
+		},
+		_on_comment_mousemove(e) {
+			if (this.comment_dragging_idx < 0 || !this._comment_drag_start) return;
+			const cd = this._canvas_data;
+			if (!cd) return;
+			const start = this._comment_drag_start;
+			const dx = e.clientX - start.clientX;
+			const dy = e.clientY - start.clientY;
+			const dxPct = (dx / cd.width) * 100;
+			const dyPct = (dy / cd.height) * 100;
+			const i = this.comment_dragging_idx;
+			const box = this.comment_boxes[i];
+			if (!box) return;
+			const newX = Math.max(0, Math.min(100, start.origXPct + dxPct));
+			const newY = Math.max(0, Math.min(100, start.origYPct + dyPct));
+			this.$set(this.comment_boxes, i, {
+				...box,
+				position_x_pct: newX,
+				position_y_pct: newY,
+			});
+		},
+		_on_comment_mouseup() {
+			if (this.comment_dragging_idx >= 0) {
+				this.comment_dragging_idx = -1;
+				this._comment_drag_start = null;
+			}
+		},
+
+		// ── Reset / save comment-style defaults ──
+		_reset_comments_to_defaults() {
+			if (!this.comment_boxes.length) return;
+			const d = this.comment_defaults || {};
+			for (let i = 0; i < this.comment_boxes.length; i++) {
+				const box = this.comment_boxes[i];
+				this.$set(this.comment_boxes, i, {
+					...box,
+					font_family: d.font_family || "Arial",
+					font_size_pct: d.font_size_pct || 5.0,
+					font_weight: d.font_weight || "Normal",
+					font_style: d.font_style || "Normal",
+					color: d.color || "#000000",
+					align: d.align || "Center",
+				});
+			}
+		},
+		_save_comment_defaults() {
+			// Save the currently-selected box's style (or box #1's if none
+			// selected) as the new system-wide default via the Settings API.
+			const idx = this.selected_comment_idx >= 0 ? this.selected_comment_idx : 0;
+			const box = this.comment_boxes[idx];
+			if (!box) {
+				frappe.show_alert({ message: __("No comment to save as default"), indicator: "orange" });
+				return;
+			}
+			frappe.call({
+				method: "frappe.client.set_value",
+				args: {
+					doctype: "Image Processing Settings",
+					name: "Image Processing Settings",
+					fieldname: {
+						default_comment_font_family: box.font_family,
+						default_comment_font_size_pct: box.font_size_pct,
+						default_comment_font_weight: box.font_weight,
+						default_comment_font_style: box.font_style,
+						default_comment_color: box.color,
+						default_comment_align: box.align,
+					},
+				},
+				callback: () => {
+					frappe.show_alert({ message: __("Comment style saved as default"), indicator: "green" });
+				},
+			});
+		},
+
 		_add_comment() {
 			const d = this.comment_defaults || {};
 			this.comment_boxes.push({
@@ -1487,11 +1778,14 @@ export default {
 		set_mode(mode) {
 			this.interaction_mode = mode;
 			if (this.cropper) {
-				// Disable/enable CropperJS drag based on mode
-				if (mode === "watermark") {
-					this.cropper.setDragMode("none");
-				} else {
+				// Disable CropperJS drag in non-crop modes so the
+				// overlay elements (watermark canvas / comment DOM
+				// boxes) can capture mouse events without the crop
+				// box stealing them.
+				if (mode === "crop") {
 					this.cropper.setDragMode("crop");
+				} else {
+					this.cropper.setDragMode("none");
 				}
 			}
 			// Repaint watermark so the corner outline picks up the new active state.
@@ -2324,6 +2618,120 @@ img {
 }
 .comment-preset-item:last-child {
 	border-bottom: none;
+}
+
+/* Draggable comment box overlay on the cropper image (new 2026-04) */
+.comment-overlay {
+	pointer-events: none;
+}
+.comment-overlay-box {
+	position: absolute;
+	border: 1px dashed rgba(59, 130, 246, 0.5);
+	box-sizing: border-box;
+	user-select: none;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+	background: rgba(255, 255, 255, 0.02);
+}
+.cropper-image-wrapper.comment-mode .comment-overlay-box {
+	cursor: move;
+	border-color: rgba(59, 130, 246, 0.75);
+	border-style: solid;
+	background: rgba(59, 130, 246, 0.04);
+}
+.cropper-image-wrapper.comment-mode .comment-overlay-box:hover {
+	background: rgba(59, 130, 246, 0.12);
+}
+.comment-overlay-box.selected {
+	border: 2px solid #3b82f6;
+}
+.comment-overlay-box.dragging {
+	opacity: 0.85;
+}
+.comment-overlay-text {
+	width: 100%;
+	padding: 2px 4px;
+	line-height: 1.15;
+	word-break: break-word;
+	white-space: pre-wrap;
+	overflow: hidden;
+	text-overflow: clip;
+}
+
+/* Enhanced comment entry controls */
+.comment-control-wide {
+	flex: 1;
+	min-width: 130px;
+}
+.comment-font-select {
+	font-size: 11px;
+	padding: 2px 4px;
+	width: 100%;
+}
+.comment-style-btn {
+	width: 26px;
+	height: 26px;
+	padding: 0;
+	border: 1px solid #cbd5e1;
+	border-radius: 3px;
+	background: #fff;
+	cursor: pointer;
+	font-size: 12px;
+	line-height: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+.comment-style-btn.active {
+	background: #3b82f6;
+	color: #fff;
+	border-color: #3b82f6;
+}
+.comment-style-btn:hover:not(.active) {
+	background: #ecf5ff;
+}
+.comment-color-input {
+	width: 28px;
+	height: 26px;
+	padding: 0;
+	border: 1px solid #cbd5e1;
+	border-radius: 3px;
+	cursor: pointer;
+}
+.comment-align-group {
+	display: inline-flex;
+	border: 1px solid #cbd5e1;
+	border-radius: 3px;
+	overflow: hidden;
+}
+.comment-align-btn {
+	width: 26px;
+	height: 26px;
+	padding: 0;
+	border: none;
+	background: #fff;
+	cursor: pointer;
+	font-size: 11px;
+	font-weight: 600;
+	border-right: 1px solid #cbd5e1;
+}
+.comment-align-btn:last-child {
+	border-right: none;
+}
+.comment-align-btn.active {
+	background: #3b82f6;
+	color: #fff;
+}
+.comment-entry-selected {
+	border-color: #3b82f6 !important;
+	box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.2);
+}
+.resize-hint {
+	font-size: 11px;
+	color: #94a3b8;
+	font-style: italic;
 }
 </style>
 

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -64,13 +64,42 @@
 						</button>
 					</div>
 				</div>
+
+				<!-- Preview block inline in the toolbar, right-aligned via
+				     margin-left: auto so the full toolbar height stays
+				     compact (~50px, determined by the taller segmented
+				     buttons and aspect ratio chips). Label sits to the
+				     left of the 50×50 thumb; thumb is an <el-image> with
+				     preview-src-list so click opens the image-viewer
+				     lightbox at full resolution. During Remove BG
+				     processing the thumb shows a spinner instead of the
+				     stale pipeline output. -->
+				<div v-if="any_feature_on" class="cropper-toolbar-preview">
+					<span class="cropper-toolbar-label">{{ __("Preview") }}:</span>
+					<div v-if="bg_processing" class="cropper-toolbar-preview-spinner" :title="__('Processing…')">
+						<div class="cropper-spinner cropper-spinner-sm"></div>
+					</div>
+					<template v-else>
+						<canvas
+							ref="preview_canvas"
+							class="cropper-preview-canvas"
+							:class="{ 'el-image-backed': !!_preview_data_url }"
+						></canvas>
+						<el-image
+							v-if="_preview_data_url"
+							class="cropper-preview-elimage"
+							:src="_preview_data_url"
+							:preview-src-list="[_preview_data_url]"
+							fit="contain"
+						/>
+					</template>
+				</div>
 			</div>
 
-			<!-- Side-by-side workspace: cropper on the left, live preview
-			     on the right at 1:1 ratio. Stacks vertically on mobile via
-			     the media query below. -->
-			<div class="cropper-workspace">
-			<!-- Cropper canvas — main image with all overlays -->
+			<!-- Cropper canvas — main image with all overlays.
+			     Occupies the full left-col below the toolbar. Preview
+			     thumb lives in the toolbar (top row, right-aligned)
+			     so it doesn't eat cropper workspace. -->
 			<div
 				class="cropper-image-wrapper"
 				ref="wrapper"
@@ -132,30 +161,6 @@
 					<div class="cropper-loading-text">{{ __("Removing background...") }}</div>
 				</div>
 			</div>
-
-			<!-- Preview column: 1:1 with the cropper on desktop (side-by-side),
-			     stacked below on mobile. The title sits above el-image so
-			     the user clearly sees "this is the final output". -->
-			<div v-if="any_feature_on" class="cropper-preview-col">
-				<div class="cropper-preview-header">
-					<span class="cropper-preview-title">{{ __("Preview") }}</span>
-					<span v-if="bg_processing" class="cropper-preview-hint">{{ __("waiting for Remove BG…") }}</span>
-					<span v-else class="cropper-preview-hint">{{ __("final output after Crop") }}</span>
-				</div>
-				<canvas
-					ref="preview_canvas"
-					class="cropper-preview-canvas"
-					:class="{ 'el-image-backed': !!_preview_data_url && !bg_processing }"
-				></canvas>
-				<el-image
-					v-if="_preview_data_url && !bg_processing"
-					class="cropper-preview-elimage"
-					:src="_preview_data_url"
-					:preview-src-list="[_preview_data_url]"
-					fit="contain"
-				/>
-			</div>
-			</div><!-- /.cropper-workspace -->
 
 		</div>
 
@@ -946,10 +951,10 @@ export default {
 
 		// Observe the cropper wrapper directly. CropperJS measures its
 		// container once on mount and doesn't auto-update when flex/grid
-		// layout shifts (e.g. the new .cropper-workspace grid finishes
-		// laying out after Vue's initial paint, leaving cropper with a
-		// 0-sized canvas that produces un-draggable / warped crop boxes).
-		// A ResizeObserver on the wrapper fixes both first-mount zero
+		// layout shifts (e.g. .cropper-image-wrapper is laid out after
+		// Vue's initial paint, leaving cropper with a 0-sized canvas
+		// that produces un-draggable / warped crop boxes). A
+		// ResizeObserver on the wrapper fixes both first-mount zero
 		// size AND devtools-triggered resizes.
 		if (typeof ResizeObserver !== "undefined" && this.$refs.wrapper) {
 			this._wrapper_ro = new ResizeObserver(() => {
@@ -1904,9 +1909,14 @@ export default {
 
 			// Refresh the <el-image> data URL from the same final_canvas
 			// so the click-to-enlarge viewer always shows current state.
+			// Use PNG whenever the final output has transparency so the
+			// preview looks identical to the cropper workspace (both dark
+			// gray showing through alpha). JPEG only when Canvas flatten
+			// is explicitly on — that's the one case where transparency
+			// is baked to a solid color and JPEG's compression wins.
 			try {
-				const fmt = (this.show_resize && this.resize_enabled && !this.resize_flatten_rgb)
-					? "image/png" : "image/jpeg";
+				const flatten = this.show_resize && this.resize_enabled && this.resize_flatten_rgb;
+				const fmt = flatten ? "image/jpeg" : "image/png";
 				this._preview_data_url = final_canvas.toDataURL(fmt, 0.88);
 			} catch (e) {
 				// toDataURL can throw on huge canvases; fall back to null
@@ -2453,37 +2463,63 @@ img {
 	max-height: min(600px, calc(100vh - 320px));
 }
 
-/* ── Preview (right half of workspace on desktop) ─────────────────
-   Fills the preview-col's remaining space after the header. Same
-   dark neutral background as the cropper, rounded corners, click
-   opens Element UI image-viewer (zoom / rotate / pan). */
+/* ── Preview inline in the top toolbar ────────────────────────────
+   50×50 thumb right-aligned in the toolbar row (margin-left: auto).
+   Matches the cropper workspace background (#2c2c2c) so transparent
+   pixels look identical to what the user is editing. Click opens
+   the Element UI image-viewer lightbox. A mini spinner replaces
+   the thumb while Remove BG is processing. */
+.cropper-toolbar-preview {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	margin-left: auto;
+}
 .cropper-preview-canvas,
 .cropper-preview-elimage {
-	flex: 1 1 auto;
-	width: 100%;
-	min-height: 0;
-	border-radius: 8px;
+	width: 50px;
+	height: 50px;
+	border-radius: 6px;
 	background: #2c2c2c;
 	overflow: hidden;
 	display: block;
 	cursor: zoom-in;
-	transition: box-shadow 0.15s ease;
+	transition: box-shadow 0.15s ease, transform 0.12s ease;
+	flex-shrink: 0;
 }
 .cropper-preview-canvas {
-	/* Fallback before the first data URL — canvas.toDataURL() writes
-	   to .style.width/height + .width/height inside _render_preview,
-	   so we keep those properties auto and just size the background. */
-	max-width: 100%;
-	max-height: 100%;
+	/* Fallback canvas before the first data URL lands in el-image.
+	   _render_preview sets internal .width/height and style.width/
+	   height directly on this canvas, so we leave those auto and
+	   only size the outer box. */
+	max-width: 50px;
+	max-height: 50px;
 }
 .cropper-preview-canvas.el-image-backed { display: none; }
 .cropper-preview-elimage:hover {
-	box-shadow: 0 0 0 2px var(--primary, #2563eb), 0 6px 14px rgba(37, 99, 235, 0.2);
+	box-shadow: 0 0 0 2px var(--primary, #2563eb), 0 4px 10px rgba(37, 99, 235, 0.22);
+	transform: scale(1.05);
 }
 .cropper-preview-elimage >>> .el-image__inner {
 	object-fit: contain;
 	width: 100%;
 	height: 100%;
+}
+/* Mini spinner that replaces the thumb while Remove BG is running. */
+.cropper-toolbar-preview-spinner {
+	width: 50px;
+	height: 50px;
+	border-radius: 6px;
+	background: #2c2c2c;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+}
+.cropper-spinner-sm {
+	width: 22px;
+	height: 22px;
+	border-width: 2px;
 }
 .cropper-preview-chips {
 	margin-top: 6px;
@@ -2683,29 +2719,20 @@ img {
 	font-weight: 500;
 }
 
-/* ── Mobile: stack left + right columns + stack the workspace ──
-   At ≤900px the grid collapses to one column and the workspace
-   (cropper + preview) stacks vertically so each gets full width
-   of the narrow viewport. Cropper keeps ~50vh, preview ~35vh. */
+/* ── Mobile: stack left + right columns ──
+   At ≤900px the outer grid collapses to one column. Cropper keeps
+   its 50vh minimum; the right panel (feature tabs + params) and
+   action bar stack below. Preview thumb stays inline in the
+   toolbar at 50×50 regardless of viewport. */
 @media (max-width: 900px) {
 	.cropper-grid {
 		grid-template-columns: 1fr;
 		grid-template-rows: auto auto auto;
 		height: auto;
 	}
-	.cropper-workspace {
-		grid-template-columns: 1fr;
-		grid-template-rows: auto auto;
-		gap: 12px;
-	}
 	.cropper-left-col { min-height: 0; }
 	.cropper-image-wrapper {
 		min-height: 50vh;
-	}
-	.cropper-preview-canvas,
-	.cropper-preview-elimage {
-		height: 35vh;
-		max-height: 320px;
 	}
 	.cropper-right-col {
 		max-height: none;
@@ -2722,10 +2749,16 @@ img {
 	.segmented-tab { padding: 7px 12px; font-size: 13px; }
 }
 @media (max-width: 480px) {
-	/* Very small phones — both rows tighter. */
+	/* Very small phones — cropper still takes most of the viewport,
+	   preview thumb shrinks slightly to free toolbar width. */
 	.cropper-image-wrapper { min-height: 40vh; }
 	.cropper-preview-canvas,
-	.cropper-preview-elimage { height: 28vh; max-height: 240px; }
+	.cropper-preview-elimage,
+	.cropper-toolbar-preview-spinner {
+		width: 40px;
+		height: 40px;
+	}
+	.cropper-preview-canvas { max-width: 40px; max-height: 40px; }
 }
 
 /* ── Unified Image Adjustments panel ──
@@ -2850,18 +2883,13 @@ img {
 	white-space: nowrap;
 }
 
-/* Workspace: cropper + preview side-by-side, 1:1 split on desktop
-   (matches Adobe Express / Remove.bg / Canva split-view pattern).
-   Stacks vertically under 900px via the media query below. */
-.cropper-workspace {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 16px;
-	flex: 1 1 auto;
-	min-height: 0;
-}
+/* Cropper takes the full height of the left column below the toolbar.
+   Preview now sits inline in the toolbar (50×50 thumb), so we don't
+   need a side-by-side split anymore. Deep neutral background so both
+   transparent and opaque images read clearly. */
 .cropper-image-wrapper {
 	position: relative;
+	flex: 1 1 auto;
 	min-height: 0;
 	min-width: 0;
 	overflow: hidden;
@@ -2872,29 +2900,6 @@ img {
 	max-width: 100%;
 	max-height: 100%;
 	display: block;
-}
-.cropper-preview-col {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-	min-width: 0;
-	min-height: 0;
-}
-.cropper-preview-header {
-	display: flex;
-	align-items: baseline;
-	gap: 8px;
-	flex-shrink: 0;
-}
-.cropper-preview-title {
-	font-weight: 600;
-	font-size: 15px;
-	color: #303133;
-}
-.cropper-preview-hint {
-	font-weight: 400;
-	font-size: 13px;
-	color: #94a3b8;
 }
 
 .cropper-image-wrapper.wm-mode {

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -65,14 +65,36 @@
 			v-if="(show_remove_bg && bg_removed && nobg_bbox) || (show_watermark && wm_enabled) || (show_resize && resize_enabled)"
 			class="adjustments-panel"
 		>
-			<!-- Output Shape (FIRST in list per UX spec) — aspect, mode, fill,
-			     flatten. Only shown when the Output Shape toggle pill is on. -->
+			<!-- Live preview of the final output (what Crop will produce).
+			     Re-renders on any param change via the preview_tick
+			     reactive dependency so the user sees the resize +
+			     watermark + flatten result before committing. -->
+			<div
+				v-if="show_resize && resize_enabled"
+				class="adjustments-row adjustments-row-preview"
+			>
+				<label class="adjustments-field-label">
+					{{ __("Preview") }}
+					<span class="adjustments-field-hint">
+						{{ __("Final output after Crop") }}
+					</span>
+				</label>
+				<div class="resize-preview-wrap">
+					<canvas ref="preview_canvas" class="resize-preview-canvas"></canvas>
+					<div v-if="preview_dims" class="resize-preview-dims">
+						{{ preview_dims.w }}×{{ preview_dims.h }}
+					</div>
+				</div>
+			</div>
+
+			<!-- Resize (FIRST in list per UX spec) — aspect, mode, fill,
+			     flatten. Only shown when the Resize toggle pill is on. -->
 			<div
 				v-if="show_resize && resize_enabled"
 				class="adjustments-row adjustments-row-resize"
 			>
 				<label class="adjustments-field-label">
-					{{ __("Output Shape") }}
+					{{ __("Resize") }}
 					<span class="adjustments-field-hint">
 						{{ __("Aspect normalization baked on Crop. Never upscales.") }}
 					</span>
@@ -313,7 +335,7 @@
 					:title="__('Normalize output aspect ({0}, {1})', [resize_aspect, resize_mode])"
 				>
 					<span class="toggle-pill-label">
-						{{ __("Output Shape") }}
+						{{ __("Resize") }}
 						<span v-if="resize_enabled" class="toggle-pill-sublabel">
 							{{ resize_aspect }}
 						</span>
@@ -405,6 +427,10 @@ export default {
 			max_file_size_kb: 2048,
 			aspect_ratio_options: ["1:1", "4:3", "16:9", "3:2", "2:3", "Free"],
 			resize_mode_options: ["Contain", "Cover", "Stretch"],
+			// Live preview (new 2026-04) — rerenders on any resize param
+			// change so the user sees exactly what Crop will produce.
+			preview_dims: null,
+			_preview_debounce: null,
 		};
 	},
 	watch: {
@@ -413,6 +439,27 @@ export default {
 				this.cropper.setAspectRatio(value);
 			}
 		},
+		// Any change to resize params → rerender the preview. Debounced
+		// so slider drags don't hammer the off-screen canvas composite.
+		resize_enabled() { this._schedule_preview_update(); },
+		resize_aspect() { this._schedule_preview_update(); },
+		resize_mode() { this._schedule_preview_update(); },
+		resize_fill_color() { this._schedule_preview_update(); },
+		resize_flatten_rgb() { this._schedule_preview_update(); },
+		// Watermark + padding also affect final output — refresh preview
+		// on those too so the user sees the composite result.
+		wm_enabled() { this._schedule_preview_update(); },
+		wm_opacity() { this._schedule_preview_update(); },
+		wm_size() { this._schedule_preview_update(); },
+		wm_pos_x() { this._schedule_preview_update(); },
+		wm_pos_y() { this._schedule_preview_update(); },
+		wm_mode() { this._schedule_preview_update(); },
+		wm_tile_size() { this._schedule_preview_update(); },
+		wm_tile_opacity() { this._schedule_preview_update(); },
+		wm_tile_rotation() { this._schedule_preview_update(); },
+		wm_tile_spacing() { this._schedule_preview_update(); },
+		local_padding_pct() { this._schedule_preview_update(); },
+		bg_removed() { this._schedule_preview_update(); },
 	},
 	mounted() {
 		// Remove BG: cached files + bbox metadata (Phase 1)
@@ -579,11 +626,16 @@ export default {
 						if (this.wm_enabled && this.wm_loaded) {
 							this.$nextTick(() => this.wm_resize_canvas());
 						}
+						// Initial preview render once cropper is ready
+						this.$nextTick(() => this._schedule_preview_update());
 					},
 					crop: () => {
 						if (this.wm_enabled && this.wm_loaded) {
 							this.$nextTick(() => this.wm_draw());
 						}
+						// Preview follows the crop box — user dragging
+						// the frame updates the preview live (debounced).
+						this._schedule_preview_update();
 					},
 				});
 			};
@@ -856,6 +908,116 @@ export default {
 			ctx.fillRect(0, 0, w, h);
 			ctx.drawImage(src_canvas, 0, 0);
 			return out;
+		},
+
+		// ── Live preview (new 2026-04) ──
+		_schedule_preview_update() {
+			if (this._preview_debounce) clearTimeout(this._preview_debounce);
+			this._preview_debounce = setTimeout(() => {
+				this._preview_debounce = null;
+				this._render_preview();
+			}, 120);
+		},
+
+		_render_preview() {
+			const preview_canvas = this.$refs.preview_canvas;
+			if (!preview_canvas) return;
+			if (!this.cropper) return;
+
+			// Run the same pipeline crop_image would, but draw to a
+			// 200×200 display canvas. Reuses _apply_output_shape so
+			// preview + actual output match exactly.
+			let src;
+			try {
+				src = this.cropper.getCroppedCanvas();
+			} catch (e) {
+				return;
+			}
+			if (!src) return;
+
+			// Apply watermark to a working copy (off-screen)
+			const work = document.createElement("canvas");
+			work.width = src.width;
+			work.height = src.height;
+			const wctx = work.getContext("2d");
+			wctx.drawImage(src, 0, 0);
+			if (this.wm_enabled && this.wm_loaded && this.wm_img) {
+				this._composite_watermark_on_canvas(work, wctx);
+			}
+
+			// Apply Resize (same helper used on final crop)
+			const final_canvas = (this.show_resize && this.resize_enabled)
+				? this._apply_output_shape(work)
+				: work;
+
+			// Compute display box: letterbox into 200×200 preserving aspect
+			const MAX = 200;
+			const ratio = final_canvas.width / final_canvas.height;
+			let disp_w, disp_h;
+			if (ratio >= 1) {
+				disp_w = MAX;
+				disp_h = Math.round(MAX / ratio);
+			} else {
+				disp_h = MAX;
+				disp_w = Math.round(MAX * ratio);
+			}
+			preview_canvas.width = disp_w;
+			preview_canvas.height = disp_h;
+			const pctx = preview_canvas.getContext("2d");
+			pctx.clearRect(0, 0, disp_w, disp_h);
+			pctx.drawImage(final_canvas, 0, 0, disp_w, disp_h);
+
+			this.preview_dims = { w: final_canvas.width, h: final_canvas.height };
+		},
+
+		// Extract the watermark composite from crop_image() so _render_preview
+		// can reuse it without duplicating the pixel math.
+		_composite_watermark_on_canvas(canvas, ctx) {
+			const image_data = this.cropper.getImageData();
+			const crop_data = this.cropper.getData();
+			const cw = canvas.width;
+			const ch = canvas.height;
+			const full_w = image_data.naturalWidth;
+			const full_h = image_data.naturalHeight;
+			const crop_x = crop_data.x;
+			const crop_y = crop_data.y;
+			const crop_w = crop_data.width;
+			const crop_h = crop_data.height;
+			const scale_x = cw / crop_w;
+			const scale_y = ch / crop_h;
+
+			if (this.wm_mode === "Tiled") {
+				const tile_w = (this.wm_tile_size / 100) * full_w * scale_x;
+				const tile_h = tile_w * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
+				const spacing_x = (this.wm_tile_spacing / 100) * full_w * scale_x;
+				const spacing_y = (this.wm_tile_spacing / 100) * full_h * scale_y;
+				const step_x = tile_w + spacing_x;
+				const step_y = tile_h + spacing_y;
+				const angle = (this.wm_tile_rotation * Math.PI) / 180;
+				ctx.save();
+				ctx.globalAlpha = this.wm_tile_opacity / 100;
+				ctx.translate(cw / 2, ch / 2);
+				ctx.rotate(angle);
+				const diag = Math.sqrt(cw * cw + ch * ch);
+				for (let y = -diag; y < diag; y += step_y) {
+					for (let x = -diag; x < diag; x += step_x) {
+						ctx.drawImage(this.wm_img, x, y, tile_w, tile_h);
+					}
+				}
+				ctx.restore();
+			} else {
+				const wm_center_x = (this.wm_pos_x / 100) * full_w;
+				const wm_center_y = (this.wm_pos_y / 100) * full_h;
+				const wm_w_full = (this.wm_size / 100) * full_w;
+				const wm_h_full = wm_w_full * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
+				const draw_x = (wm_center_x - wm_w_full / 2 - crop_x) * scale_x;
+				const draw_y = (wm_center_y - wm_h_full / 2 - crop_y) * scale_y;
+				const draw_w = wm_w_full * scale_x;
+				const draw_h = wm_h_full * scale_y;
+				ctx.globalAlpha = this.wm_opacity / 100;
+				ctx.drawImage(this.wm_img, draw_x, draw_y, draw_w, draw_h);
+				ctx.globalAlpha = 1.0;
+			}
 		},
 
 		// ── Remove BG ──
@@ -1753,6 +1915,48 @@ img {
 .segmented-tab.disabled {
 	opacity: 0.5;
 	cursor: not-allowed;
+}
+
+/* Live preview canvas (new 2026-04) — shown at the top of the
+   adjustments panel whenever Resize is on, so the user can see
+   exactly what the final output will look like before clicking Crop. */
+.adjustments-row-preview {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.resize-preview-wrap {
+	position: relative;
+	display: inline-block;
+	padding: 8px;
+	background: #fafbfc;
+	border: 1px solid #e5edf8;
+	border-radius: 6px;
+	align-self: flex-start;
+}
+.resize-preview-canvas {
+	display: block;
+	background: #ffffff;
+	/* checkerboard so users know where transparency is */
+	background-image:
+		linear-gradient(45deg, #f0f0f0 25%, transparent 25%),
+		linear-gradient(-45deg, #f0f0f0 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #f0f0f0 75%),
+		linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
+	background-size: 16px 16px;
+	background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+	min-width: 60px;
+	min-height: 60px;
+	max-width: 200px;
+	max-height: 200px;
+	border: 1px solid #cbd5e1;
+}
+.resize-preview-dims {
+	margin-top: 6px;
+	font-size: 11px;
+	color: #64748b;
+	text-align: center;
+	font-variant-numeric: tabular-nums;
 }
 </style>
 

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -66,6 +66,10 @@
 				</div>
 			</div>
 
+			<!-- Side-by-side workspace: cropper on the left, live preview
+			     on the right at 1:1 ratio. Stacks vertically on mobile via
+			     the media query below. -->
+			<div class="cropper-workspace">
 			<!-- Cropper canvas — main image with all overlays -->
 			<div
 				class="cropper-image-wrapper"
@@ -129,25 +133,29 @@
 				</div>
 			</div>
 
-			<!-- Preview — compact 400×400 thumb that matches the Item
-			     Image Batch row-thumbnail pattern. No outer card /
-			     header wrapper: the <el-image> is the whole thing,
-			     sitting directly in the left-col flex flow. Click
-			     opens Element UI's image-viewer lightbox. -->
-			<template v-if="any_feature_on">
+			<!-- Preview column: 1:1 with the cropper on desktop (side-by-side),
+			     stacked below on mobile. The title sits above el-image so
+			     the user clearly sees "this is the final output". -->
+			<div v-if="any_feature_on" class="cropper-preview-col">
+				<div class="cropper-preview-header">
+					<span class="cropper-preview-title">{{ __("Preview") }}</span>
+					<span v-if="bg_processing" class="cropper-preview-hint">{{ __("waiting for Remove BG…") }}</span>
+					<span v-else class="cropper-preview-hint">{{ __("final output after Crop") }}</span>
+				</div>
 				<canvas
 					ref="preview_canvas"
 					class="cropper-preview-canvas"
-					:class="{ 'el-image-backed': !!_preview_data_url }"
+					:class="{ 'el-image-backed': !!_preview_data_url && !bg_processing }"
 				></canvas>
 				<el-image
-					v-if="_preview_data_url"
+					v-if="_preview_data_url && !bg_processing"
 					class="cropper-preview-elimage"
 					:src="_preview_data_url"
 					:preview-src-list="[_preview_data_url]"
 					fit="contain"
 				/>
-			</template>
+			</div>
+			</div><!-- /.cropper-workspace -->
 
 		</div>
 
@@ -785,7 +793,29 @@ export default {
 		wm_tile_rotation() { this._schedule_preview_update(); },
 		wm_tile_spacing() { this._schedule_preview_update(); },
 		local_padding_pct() { this._schedule_preview_update(); },
-		bg_removed() { this._schedule_preview_update(); },
+		bg_removed() {
+			// Clear any stale preview immediately so the user doesn't see
+			// the pre-removal image while the new crop + composite runs.
+			// _schedule_preview_update is debounced (120ms) + cropper may
+			// still be swapping the underlying image — without this reset
+			// the user could briefly see the old Remove BG state.
+			this._preview_data_url = null;
+			this._schedule_preview_update();
+		},
+		bg_processing(processing) {
+			// Clear the preview while bg removal is in flight so
+			// _render_preview doesn't snapshot an inconsistent
+			// intermediate state (and _preview_data_url-based v-if gates
+			// the el-image + canvas.el-image-backed behavior).
+			if (processing) {
+				this._preview_data_url = null;
+			} else {
+				// When processing flips off, cropper.swap() has just
+				// bound the new image. Wait a tick for cropper's
+				// internal DOM to settle, then re-render preview.
+				this.$nextTick(() => this._schedule_preview_update());
+			}
+		},
 		comments_enabled() { this._schedule_preview_update(); },
 		comment_boxes: {
 			handler() { this._schedule_preview_update(); },
@@ -902,9 +932,44 @@ export default {
 				// Preview thumb's container changes size with the modal,
 				// so re-render the preview at the new resolution.
 				this._schedule_preview_update();
+				// CropperJS doesn't observe its own container element —
+				// it relies on window resize. When our wrapper changes
+				// size without a window resize (e.g. the side-by-side
+				// grid re-flows because the modal was opened at 0×0
+				// then laid out), we need to tell cropper to re-measure.
+				if (this.cropper) {
+					try { this.cropper.resize(); } catch (e) {}
+				}
 			});
 		};
 		window.addEventListener("resize", this._on_window_resize);
+
+		// Observe the cropper wrapper directly. CropperJS measures its
+		// container once on mount and doesn't auto-update when flex/grid
+		// layout shifts (e.g. the new .cropper-workspace grid finishes
+		// laying out after Vue's initial paint, leaving cropper with a
+		// 0-sized canvas that produces un-draggable / warped crop boxes).
+		// A ResizeObserver on the wrapper fixes both first-mount zero
+		// size AND devtools-triggered resizes.
+		if (typeof ResizeObserver !== "undefined" && this.$refs.wrapper) {
+			this._wrapper_ro = new ResizeObserver(() => {
+				if (!this.cropper) return;
+				// Debounce with rAF so rapid size changes don't thrash
+				// cropper.resize().
+				if (this._wrapper_ro_raf) return;
+				this._wrapper_ro_raf = requestAnimationFrame(() => {
+					this._wrapper_ro_raf = null;
+					try {
+						this.cropper.resize();
+					} catch (e) {}
+					if (this.wm_enabled && this.wm_loaded) {
+						this.wm_resize_canvas();
+					}
+					this._schedule_preview_update();
+				});
+			});
+			this._wrapper_ro.observe(this.$refs.wrapper);
+		}
 
 		// Mark the enclosing Bootstrap modal-body so our scoped CSS can enable
 		// internal scrolling — otherwise very tall images + section cards push
@@ -941,6 +1006,11 @@ export default {
 		document.removeEventListener("touchend", this._on_touchend);
 		window.removeEventListener("resize", this._on_window_resize);
 		if (this._resize_raf) cancelAnimationFrame(this._resize_raf);
+		if (this._wrapper_ro_raf) cancelAnimationFrame(this._wrapper_ro_raf);
+		if (this._wrapper_ro) {
+			try { this._wrapper_ro.disconnect(); } catch (e) {}
+			this._wrapper_ro = null;
+		}
 		if (this._modal_body_el) {
 			this._modal_body_el.classList.remove("image-cropper-modal-body");
 		}
@@ -2383,33 +2453,32 @@ img {
 	max-height: min(600px, calc(100vh - 320px));
 }
 
-/* ── Preview thumb below cropper ──────────────────────────────────
-   Bare 400×400 el-image, no outer card / header wrapper. Sits
-   directly in the left-col flex flow, left-aligned. Matches the
-   Item Image Batch row-thumbnail visual language (deep background,
-   rounded corners, zoom-on-hover). Click → Element UI image-viewer. */
+/* ── Preview (right half of workspace on desktop) ─────────────────
+   Fills the preview-col's remaining space after the header. Same
+   dark neutral background as the cropper, rounded corners, click
+   opens Element UI image-viewer (zoom / rotate / pan). */
 .cropper-preview-canvas,
 .cropper-preview-elimage {
-	align-self: flex-start;
-	width: 400px;
-	height: 400px;
-	flex-shrink: 0;
+	flex: 1 1 auto;
+	width: 100%;
+	min-height: 0;
 	border-radius: 8px;
 	background: #2c2c2c;
 	overflow: hidden;
 	display: block;
 	cursor: zoom-in;
-	transition: box-shadow 0.15s ease, transform 0.12s ease;
+	transition: box-shadow 0.15s ease;
 }
 .cropper-preview-canvas {
-	/* Fallback before el-image mounts with the first data URL. */
+	/* Fallback before the first data URL — canvas.toDataURL() writes
+	   to .style.width/height + .width/height inside _render_preview,
+	   so we keep those properties auto and just size the background. */
 	max-width: 100%;
 	max-height: 100%;
 }
 .cropper-preview-canvas.el-image-backed { display: none; }
 .cropper-preview-elimage:hover {
 	box-shadow: 0 0 0 2px var(--primary, #2563eb), 0 6px 14px rgba(37, 99, 235, 0.2);
-	transform: scale(1.01);
 }
 .cropper-preview-elimage >>> .el-image__inner {
 	object-fit: contain;
@@ -2614,26 +2683,29 @@ img {
 	font-weight: 500;
 }
 
-/* ── Mobile: stack left + right columns ──
-   Grid collapses to one column. Cropper stays dominant (~60vh),
-   preview becomes a compact row with a 160×160 thumb. Right panel
-   scrolls naturally with the page so user sees
-   cropper → preview → params → Crop. */
+/* ── Mobile: stack left + right columns + stack the workspace ──
+   At ≤900px the grid collapses to one column and the workspace
+   (cropper + preview) stacks vertically so each gets full width
+   of the narrow viewport. Cropper keeps ~50vh, preview ~35vh. */
 @media (max-width: 900px) {
 	.cropper-grid {
 		grid-template-columns: 1fr;
 		grid-template-rows: auto auto auto;
 		height: auto;
 	}
+	.cropper-workspace {
+		grid-template-columns: 1fr;
+		grid-template-rows: auto auto;
+		gap: 12px;
+	}
 	.cropper-left-col { min-height: 0; }
 	.cropper-image-wrapper {
-		flex: 0 0 auto;
-		min-height: 60vh;
+		min-height: 50vh;
 	}
 	.cropper-preview-canvas,
 	.cropper-preview-elimage {
-		width: 260px;
-		height: 260px;
+		height: 35vh;
+		max-height: 320px;
 	}
 	.cropper-right-col {
 		max-height: none;
@@ -2650,13 +2722,10 @@ img {
 	.segmented-tab { padding: 7px 12px; font-size: 13px; }
 }
 @media (max-width: 480px) {
-	/* Very small phones — smaller cropper + thumb to fit a single swipe. */
-	.cropper-image-wrapper { min-height: 50vh; }
+	/* Very small phones — both rows tighter. */
+	.cropper-image-wrapper { min-height: 40vh; }
 	.cropper-preview-canvas,
-	.cropper-preview-elimage {
-		width: 180px;
-		height: 180px;
-	}
+	.cropper-preview-elimage { height: 28vh; max-height: 240px; }
 }
 
 /* ── Unified Image Adjustments panel ──
@@ -2781,16 +2850,20 @@ img {
 	white-space: nowrap;
 }
 
-.cropper-image-wrapper {
-	position: relative;
-	/* Cropper dominates the left column — takes remaining height
-	   above the fixed-size preview thumb. Deep neutral background
-	   (Photopea / Figma palette) so both colored photos and
-	   transparent PNGs read clearly; PNG transparency shows as
-	   the same dark gray, and Canvas output with solid fill shows
-	   the fill color, making the two states easy to distinguish. */
+/* Workspace: cropper + preview side-by-side, 1:1 split on desktop
+   (matches Adobe Express / Remove.bg / Canva split-view pattern).
+   Stacks vertically under 900px via the media query below. */
+.cropper-workspace {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
 	flex: 1 1 auto;
 	min-height: 0;
+}
+.cropper-image-wrapper {
+	position: relative;
+	min-height: 0;
+	min-width: 0;
 	overflow: hidden;
 	background: #2c2c2c;
 	border-radius: 8px;
@@ -2799,6 +2872,29 @@ img {
 	max-width: 100%;
 	max-height: 100%;
 	display: block;
+}
+.cropper-preview-col {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	min-width: 0;
+	min-height: 0;
+}
+.cropper-preview-header {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	flex-shrink: 0;
+}
+.cropper-preview-title {
+	font-weight: 600;
+	font-size: 15px;
+	color: #303133;
+}
+.cropper-preview-hint {
+	font-weight: 400;
+	font-size: 13px;
+	color: #94a3b8;
 }
 
 .cropper-image-wrapper.wm-mode {

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -2526,22 +2526,28 @@ img {
 .wm-slider-row {
 	display: flex;
 	align-items: center;
-	gap: 10px;
+	gap: 12px;
+	margin-bottom: 6px;
+}
+.wm-slider-row:last-child {
+	margin-bottom: 0;
 }
 .wm-slider-row .wm-slider-label {
-	width: 80px;
-	font-size: 11px;
-	color: #606266;
+	width: 100px;
+	font-size: 15px;
+	font-weight: 500;
+	color: #475569;
 }
 .wm-slider-row .wm-slider {
 	flex: 1;
 }
 .wm-slider-row .wm-slider-value {
-	width: 40px;
-	font-size: 11px;
+	width: 52px;
+	font-size: 14px;
 	color: #303133;
 	text-align: right;
 	font-variant-numeric: tabular-nums;
+	font-weight: 500;
 }
 
 /* ── Mobile: stack left + right columns ── */
@@ -2552,6 +2558,12 @@ img {
 	.cropper-feature-tabs {
 		grid-template-columns: repeat(4, 1fr);
 	}
+	.cropper-feature-tab-label { font-size: 14px; }
+	.cropper-feature-tab-state { font-size: 12px; }
+	.cropper-tab-enable-label { font-size: 15px; }
+	.wm-slider-row .wm-slider-label { width: 82px; font-size: 13px; }
+	.wm-slider-row .wm-slider-value { width: 44px; font-size: 12px; }
+	.segmented-tab { padding: 7px 12px; font-size: 13px; }
 }
 
 /* ── Unified Image Adjustments panel ──
@@ -2575,7 +2587,7 @@ img {
 .adjustments-field-label {
 	display: block;
 	margin: 0 0 6px;
-	font-size: 12px;
+	font-size: 14px;
 	font-weight: 600;
 	color: var(--text-color);
 	letter-spacing: 0.01em;
@@ -2622,10 +2634,10 @@ img {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	padding: 6px 16px;
+	padding: 8px 18px;
 	border: none;
 	border-radius: 6px;
-	font-size: var(--text-sm);
+	font-size: 14px;
 	font-weight: 500;
 	color: var(--text-color);
 	background: transparent;
@@ -2856,7 +2868,7 @@ img {
 	border: none;
 	outline: none;
 	background: transparent;
-	font-size: var(--text-sm);
+	font-size: 14px;
 	color: var(--text-color);
 	padding: 0 6px;
 	min-width: 0;
@@ -2871,7 +2883,7 @@ img {
 }
 
 .wm-input-suffix {
-	font-size: 11px;
+	font-size: 13px;
 	color: var(--text-muted);
 	padding: 0 6px;
 	user-select: none;
@@ -2917,13 +2929,13 @@ img {
 .wm-panel-actions {
 	display: flex;
 	justify-content: flex-end;
-	gap: 6px;
-	margin-top: 8px;
+	gap: 8px;
+	margin-top: 12px;
 }
 
 .wm-panel-actions .btn-xs {
-	font-size: 11px;
-	padding: 2px 10px;
+	font-size: 13px;
+	padding: 5px 14px;
 	line-height: 1.6;
 }
 

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -752,6 +752,16 @@ export default {
 				this.cropper.setAspectRatio(value);
 			}
 		},
+		// Switching tabs should immediately re-render the preview so the
+		// user sees the new tab's settings baked into the thumb. The
+		// other watchers only fire when a value changes — switching
+		// tabs doesn't change any param but the user expects the
+		// preview to reflect what the tab represents (particularly
+		// Canvas, where the user wants to see the target aspect ratio
+		// applied the moment they click the tab).
+		active_tab() {
+			this._schedule_preview_update();
+		},
 		// Any change to resize params → rerender the preview. Debounced
 		// so slider drags don't hammer the off-screen canvas composite.
 		resize_enabled(v) {
@@ -842,7 +852,12 @@ export default {
 			this.resize_aspect = this.resize_settings.resize_aspect || "1:1";
 			this.resize_mode = this.resize_settings.resize_mode || "Contain";
 			this.resize_fill_color = this.resize_settings.resize_fill_color || "#FFFFFF";
-			this.resize_flatten_rgb = !!this.resize_settings.resize_flatten_rgb;
+			// Default to true when the settings object has no explicit
+			// value (undefined) — the doctype default is 1, so a newly
+			// installed site shouldn't accidentally produce transparent
+			// PNGs just because the settings object was cached before
+			// this field existed.
+			this.resize_flatten_rgb = this.resize_settings.resize_flatten_rgb !== false;
 			// (max_file_size_kb is global Settings only; not read here)
 		}
 

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1423,26 +1423,30 @@ export default {
 				this._composite_comments_on_canvas(canvas, cctx);
 			}
 
-			// If Solid Background is on, flatten the cropped canvas onto
-			// the chosen colour before encoding. Produces JPEG (opaque,
-			// smaller); otherwise keep alpha as PNG when Remove BG /
-			// Watermark ran, or fall back to the source type.
+			// Always encode as PNG. Solid Background flattens alpha onto
+			// the chosen colour (still PNG — RGB-only PNGs are typically
+			// smaller than RGBA PNGs anyway, and we avoid JPEG's lossy
+			// compression on product-edge detail). Off keeps alpha intact.
 			let final_canvas = canvas;
-			let file_type;
 			if (this.solid_background) {
 				final_canvas = this._flatten_onto_colour(canvas, this.background_color || "#FFFFFF");
-				file_type = "image/jpeg";
-			} else if (this.bg_removed || this.wm_enabled) {
-				file_type = "image/png";
-			} else {
-				file_type = this.file.file_obj.type;
 			}
+			const file_type = "image/png";
 
 			final_canvas.toBlob((blob) => {
-				let name = this.file.name;
-				if (this.bg_removed) name = name.replace(/\.[^.]+$/, "_nobg.png");
-				if (this.wm_enabled) name = name.replace(/\.[^.]+$/, "_wm.png");
-				if (this.solid_background) name = name.replace(/\.[^.]+$/, ".jpg");
+				// Build a single new filename: stem + active-suffixes + .png.
+				// Using `.replace(/\.[^.]+$/, ...)` repeatedly eats
+				// previously-added suffixes — e.g. foo.jpg → foo_nobg.png
+				// → foo_wm.png (the _nobg disappears). Compose the stem
+				// once and append all active suffixes together instead.
+				const original = this.file.name || "image.png";
+				const dot = original.lastIndexOf(".");
+				const stem = dot > 0 ? original.slice(0, dot) : original;
+				const suffixes = [];
+				if (this.bg_removed) suffixes.push("_nobg");
+				if (this.wm_enabled) suffixes.push("_wm");
+				if (this.solid_background) suffixes.push("_bg");
+				const name = stem + suffixes.join("") + ".png";
 				this.file.file_obj = new File([blob], name, { type: blob.type });
 				this.file.name = name;
 				// Emit the final settings snapshot so FileUploader's Step 3
@@ -1479,7 +1483,7 @@ export default {
 					background_color: this.background_color,
 				});
 				this.$emit("toggle_image_cropper");
-			}, file_type, file_type === "image/jpeg" ? 0.92 : undefined);
+			}, file_type);
 		},
 
 		// Paint `src` on top of a solid-colour fill canvas of the same

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -83,13 +83,13 @@
 						<canvas
 							ref="preview_canvas"
 							class="cropper-preview-canvas"
-							:class="{ 'el-image-backed': !!_preview_data_url }"
+							:class="{ 'el-image-backed': !!preview_data_url }"
 						></canvas>
 						<el-image
-							v-if="_preview_data_url"
+							v-if="preview_data_url"
 							class="cropper-preview-elimage"
-							:src="_preview_data_url"
-							:preview-src-list="[_preview_data_url]"
+							:src="preview_data_url"
+							:preview-src-list="[preview_data_url]"
 							fit="contain"
 						/>
 					</template>
@@ -730,7 +730,7 @@ export default {
 			// Full-resolution data URL fed into <el-image> preview-src-list.
 			// Updated on every preview render so clicking the thumb
 			// always opens the current state of the pipeline.
-			_preview_data_url: null,
+			preview_data_url: null,
 			_preview_debounce: null,
 			// Comments (new 2026-04) — list of text overlays baked into
 			// the final Canvas composite. Overlay DOM boxes on top of the
@@ -804,16 +804,16 @@ export default {
 			// _schedule_preview_update is debounced (120ms) + cropper may
 			// still be swapping the underlying image — without this reset
 			// the user could briefly see the old Remove BG state.
-			this._preview_data_url = null;
+			this.preview_data_url = null;
 			this._schedule_preview_update();
 		},
 		bg_processing(processing) {
 			// Clear the preview while bg removal is in flight so
 			// _render_preview doesn't snapshot an inconsistent
-			// intermediate state (and _preview_data_url-based v-if gates
+			// intermediate state (and preview_data_url-based v-if gates
 			// the el-image + canvas.el-image-backed behavior).
 			if (processing) {
-				this._preview_data_url = null;
+				this.preview_data_url = null;
 			} else {
 				// When processing flips off, cropper.swap() has just
 				// bound the new image. Wait a tick for cropper's
@@ -1917,10 +1917,10 @@ export default {
 			try {
 				const flatten = this.show_resize && this.resize_enabled && this.resize_flatten_rgb;
 				const fmt = flatten ? "image/jpeg" : "image/png";
-				this._preview_data_url = final_canvas.toDataURL(fmt, 0.88);
+				this.preview_data_url = final_canvas.toDataURL(fmt, 0.88);
 			} catch (e) {
 				// toDataURL can throw on huge canvases; fall back to null
-				this._preview_data_url = null;
+				this.preview_data_url = null;
 			}
 		},
 

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1300,9 +1300,11 @@ export default {
 		async save_crop_defaults() {
 			// Persist the full Crop-toolbar state (aspect + solid
 			// background + colour) as system-wide defaults in Image
-			// Processing Settings. Updating in-process cache too so
-			// re-opening the uploader without refreshing picks up the
-			// new defaults. Mirrors save_padding_default.
+			// Processing Settings. After the write, refetch the full
+			// settings object so the in-process cache is guaranteed to
+			// match whatever the server returns (rather than just the
+			// three fields we wrote — protects against a mismatch if
+			// Settings grows new fields that depend on these).
 			const aspect = this._aspect_number_to_string(this.aspect_ratio);
 			const solid = this.solid_background ? 1 : 0;
 			const colour = this.background_color || "#FFFFFF";
@@ -1319,10 +1321,27 @@ export default {
 						},
 					},
 				});
-				if (frappe._image_processing_settings_cache) {
-					frappe._image_processing_settings_cache.crop_aspect = aspect;
-					frappe._image_processing_settings_cache.solid_background = !!solid;
-					frappe._image_processing_settings_cache.background_color = colour;
+				// Refetch the settings cache so the next uploader opens
+				// with the just-saved values. Without this, users who
+				// clicked Save but didn't refresh the page saw the old
+				// defaults on the next Upload click because item.js
+				// reads from the in-memory cache, not the DB.
+				try {
+					const resp = await frappe.call({
+						method: "next.next.doctype.image_processing_settings.image_processing_settings.get_image_processing_settings",
+					});
+					if (resp && resp.message) {
+						frappe._image_processing_settings_cache = resp.message;
+					}
+				} catch (e) {
+					// Fall back to patching the three fields locally if
+					// the refetch fails (e.g. network hiccup) — the write
+					// itself already succeeded.
+					if (frappe._image_processing_settings_cache) {
+						frappe._image_processing_settings_cache.crop_aspect = aspect;
+						frappe._image_processing_settings_cache.solid_background = !!solid;
+						frappe._image_processing_settings_cache.background_color = colour;
+					}
 				}
 				frappe.show_alert({
 					message: __("Crop defaults saved"),

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -97,22 +97,30 @@
 			</div>
 
 			<!-- Cropper canvas — main image with all overlays.
-			     Occupies the full left-col below the toolbar. Preview
-			     thumb lives in the toolbar (top row, right-aligned)
-			     so it doesn't eat cropper workspace. -->
-			<div
-				class="cropper-image-wrapper"
-				ref="wrapper"
-				:class="{
-					'wm-mode': interaction_mode === 'watermark' && wm_mode === 'Corner',
-					'comment-mode': interaction_mode === 'comment',
-					'bg-processing': bg_processing,
-				}"
-				@mousedown="on_wrapper_mousedown"
-				@wheel.prevent="on_wrapper_wheel"
-				@touchstart="on_wrapper_touchstart"
-			>
-				<img ref="image" :src="src" :alt="file.name" />
+			     Two-level layout:
+			       .cropper-image-stage  — the flex-growing dark backdrop.
+			       .cropper-image-wrapper — sized to the image's natural
+			         aspect ratio so there is NO "grey dead-zone" outside
+			         the picture. The image's edge is visually obvious
+			         (distinct bg + border), and the crop box's constraint
+			         stops exactly at that edge — matching every common
+			         image-cropper UX (Photoshop / Figma / Lightroom /
+			         Instagram). -->
+			<div class="cropper-image-stage">
+				<div
+					class="cropper-image-wrapper"
+					ref="wrapper"
+					:class="{
+						'wm-mode': interaction_mode === 'watermark' && wm_mode === 'Corner',
+						'comment-mode': interaction_mode === 'comment',
+						'bg-processing': bg_processing,
+					}"
+					:style="wrapper_aspect_style"
+					@mousedown="on_wrapper_mousedown"
+					@wheel.prevent="on_wrapper_wheel"
+					@touchstart="on_wrapper_touchstart"
+				>
+					<img ref="image" :src="src" :alt="file.name" @load="on_image_load" />
 				<canvas
 					v-if="wm_enabled && wm_loaded"
 					ref="wm_canvas"
@@ -159,6 +167,7 @@
 				<div v-if="bg_processing" class="cropper-loading-overlay">
 					<div class="cropper-spinner"></div>
 					<div class="cropper-loading-text">{{ __("Removing background...") }}</div>
+				</div>
 				</div>
 			</div>
 
@@ -768,6 +777,11 @@ export default {
 			// Canvas data cache (image display rect in cropper wrapper)
 			// updated on cropper ready + crop event for overlay positioning.
 			_canvas_data: null,
+			// Natural aspect ratio (w/h) of the source image, driven by the
+			// <img @load> handler. Used to size .cropper-image-wrapper to
+			// exactly the picture's contain-bbox so the crop box can't be
+			// dragged into empty dead-zones.
+			natural_aspect_ratio: null,
 			comment_font_families: [
 				"Arial", "Helvetica", "Times New Roman",
 				"Courier New", "Georgia", "Verdana",
@@ -1057,6 +1071,15 @@ export default {
 		}
 	},
 	computed: {
+		// CSS binding that sizes .cropper-image-wrapper to the source image's
+		// natural aspect ratio. Combined with max-width/max-height:100% in
+		// the stylesheet this gives a perfect contain-fit inside the stage,
+		// so the wrapper box edge == the image edge (no grey dead-zone the
+		// crop box can't reach).
+		wrapper_aspect_style() {
+			if (!this.natural_aspect_ratio) return {};
+			return { aspectRatio: String(this.natural_aspect_ratio) };
+		},
 		aspect_ratio_buttons() {
 			return [
 				{ label: __("1:1"), value: 1 },
@@ -1134,6 +1157,16 @@ export default {
 		},
 	},
 	methods: {
+		// Capture the source image's natural aspect ratio so the wrapper
+		// box (which CropperJS mounts on) sizes exactly to the image's
+		// contain-fit rect. Runs before init_cropper because CropperJS
+		// reads the container size once on mount.
+		on_image_load(e) {
+			const img = e && e.target;
+			if (img && img.naturalWidth && img.naturalHeight) {
+				this.natural_aspect_ratio = img.naturalWidth / img.naturalHeight;
+			}
+		},
 		// ── Image loading ──
 		load_image(file) {
 			if (window.FileReader) {
@@ -1149,6 +1182,19 @@ export default {
 			if (this.cropper) this.cropper.destroy();
 			let crop_box = this.file.crop_box_data;
 			this.image = this.$refs.image;
+			// Ensure the wrapper aspect ratio is set before CropperJS mounts —
+			// CropperJS reads the container size once, so a stale wrapper box
+			// leaves dead space around the picture. Vue's @load usually fires
+			// this, but for fast data URL decodes the browser may skip the
+			// load event if the image is already complete in cache.
+			if (
+				this.image &&
+				this.image.naturalWidth &&
+				this.image.naturalHeight
+			) {
+				this.natural_aspect_ratio =
+					this.image.naturalWidth / this.image.naturalHeight;
+			}
 			this.image.onload = () => {
 				this.cropper = new Cropper(this.image, {
 					zoomable: false,
@@ -2968,18 +3014,53 @@ img {
 	white-space: nowrap;
 }
 
-/* Cropper takes the full height of the left column below the toolbar.
-   Preview now sits inline in the toolbar (50×50 thumb), so we don't
-   need a side-by-side split anymore. Deep neutral background so both
-   transparent and opaque images read clearly. */
-.cropper-image-wrapper {
+/* Two-level cropper layout.
+   .cropper-image-stage — the dark flex-filling backdrop (shows around
+     the picture when the workspace aspect differs from the image).
+   .cropper-image-wrapper — sized to the image's natural aspect ratio
+     via :style="wrapper_aspect_style" so its bounding rect matches the
+     actual image display rect. CropperJS mounts on this, so the crop
+     box's bounds equal the image edges — no grey dead-zone the box
+     can't reach. Matches Photoshop / Figma / Lightroom behaviour. */
+.cropper-image-stage {
 	position: relative;
 	flex: 1 1 auto;
 	min-height: 0;
 	min-width: 0;
-	overflow: hidden;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	background: #2c2c2c;
 	border-radius: 8px;
+	padding: 12px;
+	overflow: hidden;
+}
+.cropper-image-wrapper {
+	position: relative;
+	max-width: 100%;
+	max-height: 100%;
+	/* aspect-ratio is applied inline via wrapper_aspect_style. Until the
+	   <img @load> handler fires (first paint / SSR-like state) fall back
+	   to 1 so the empty box has a sane shape. */
+	aspect-ratio: 1;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	border-radius: 4px;
+	/* Subtle checkerboard shows through transparent PNGs so the user can
+	   see "this area is transparent" instead of guessing from grey. */
+	background-color: #fdfdfd;
+	background-image:
+		linear-gradient(45deg, #e9edf2 25%, transparent 25%),
+		linear-gradient(-45deg, #e9edf2 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #e9edf2 75%),
+		linear-gradient(-45deg, transparent 75%, #e9edf2 75%);
+	background-size: 16px 16px;
+	background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+	/* Distinct border so the image's edge is visually obvious — the
+	   crop box stops exactly here. */
+	box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.18),
+		0 4px 18px rgba(0, 0, 0, 0.35);
 }
 .cropper-image-wrapper img {
 	max-width: 100%;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -130,30 +130,28 @@
 			</div>
 
 			<!-- Preview strip: dedicated row under the cropper. Label on top
-			     acts as the visual divider, thumbnail centered underneath
-			     at 1:1 height with the cropper above. Clicking the thumb
-			     opens an Element UI image-viewer (zoom + rotate) when the
-			     bundle is loaded; falls back to a plain canvas on forms
-			     where element-ui isn't registered. -->
+			     acts as the visual divider; thumbnail centered underneath
+			     at 1:1 height with the cropper above. The thumb is an
+			     <el-image> with preview-src-list so click opens Element
+			     UI's image-viewer (zoom / rotate / pan). El-image lazy-
+			     renders an img from the data URL produced by the preview
+			     pipeline, which we refresh every time Canvas settings
+			     change via _refresh_preview_src(). -->
 			<div class="cropper-preview-bar" v-if="any_feature_on">
 				<div class="cropper-preview-header">
 					<span class="cropper-preview-title">{{ __("Preview") }}</span>
 					<span class="cropper-preview-hint">{{ __("final output after Crop") }}</span>
 				</div>
-				<div class="cropper-preview-thumb" @click="_open_preview_viewer">
-					<canvas ref="preview_canvas" class="resize-preview-canvas"></canvas>
-					<div class="cropper-preview-zoom" :title="__('Click to enlarge')">
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><path d="M11 8v6"/><path d="M8 11h6"/></svg>
-					</div>
+				<div class="cropper-preview-thumb">
+					<canvas ref="preview_canvas" class="resize-preview-canvas" :class="{ 'el-image-backed': !!_preview_data_url }"></canvas>
+					<el-image
+						v-if="_preview_data_url"
+						class="cropper-preview-elimage"
+						:src="_preview_data_url"
+						:preview-src-list="[_preview_data_url]"
+						fit="contain"
+					/>
 				</div>
-			</div>
-			<!-- Lazy-mounted el-image viewer — only inserted when user clicks
-			     the zoom. We use the viewer widget directly (not wrapping
-			     <el-image>) so the cropper panel doesn't require
-			     element-ui to be loaded globally. -->
-			<div v-if="_preview_viewer_open && _preview_data_url" class="cropper-preview-viewer-host" @click.self="_preview_viewer_open = false">
-				<img :src="_preview_data_url" class="cropper-preview-viewer-img" @click.stop />
-				<button class="cropper-preview-viewer-close" @click="_preview_viewer_open = false" :title="__('Close')">×</button>
 			</div>
 
 		</div>
@@ -721,11 +719,9 @@ export default {
 			// Live preview (new 2026-04) — rerenders on any resize param
 			// change so the user sees exactly what Crop will produce.
 			preview_dims: null,
-			// Lightbox state for the preview thumbnail: click opens a
-			// full-size overlay (data URL snapshot of the current preview
-			// canvas) so the user can inspect the final baked output
-			// without leaving the cropper.
-			_preview_viewer_open: false,
+			// Full-resolution data URL fed into <el-image> preview-src-list.
+			// Updated on every preview render so clicking the thumb
+			// always opens the current state of the pipeline.
 			_preview_data_url: null,
 			_preview_debounce: null,
 			// Comments (new 2026-04) — list of text overlays baked into
@@ -925,14 +921,6 @@ export default {
 				this._modal_body_el = body;
 			}
 		});
-
-		// ESC key closes the preview lightbox overlay when open.
-		this._on_doc_keydown = (e) => {
-			if (e.key === "Escape" && this._preview_viewer_open) {
-				this._preview_viewer_open = false;
-			}
-		};
-		document.addEventListener("keydown", this._on_doc_keydown);
 	},
 	beforeDestroy() {
 		document.removeEventListener("mousemove", this._on_mousemove);
@@ -942,7 +930,6 @@ export default {
 		document.removeEventListener("touchmove", this._on_touchmove);
 		document.removeEventListener("touchend", this._on_touchend);
 		window.removeEventListener("resize", this._on_window_resize);
-		if (this._on_doc_keydown) document.removeEventListener("keydown", this._on_doc_keydown);
 		if (this._resize_raf) cancelAnimationFrame(this._resize_raf);
 		if (this._modal_body_el) {
 			this._modal_body_el.classList.remove("image-cropper-modal-body");
@@ -1761,44 +1748,6 @@ export default {
 		},
 
 		// ── Live preview (new 2026-04) ──
-		// Click handler on the preview thumb — snapshot the current
-		// preview canvas to a data URL and open an overlay with the
-		// full-resolution final output. We take the snapshot from the
-		// post-composite canvas rather than the live cropper so the
-		// user sees exactly what will be uploaded.
-		_open_preview_viewer() {
-			const canvas = this.$refs.preview_canvas;
-			if (!canvas) return;
-			try {
-				// Render a higher-resolution preview for the viewer by
-				// re-running the composite pipeline at the cropper's
-				// natural size, then serializing to a data URL.
-				const src = this.cropper ? this.cropper.getCroppedCanvas() : null;
-				if (src) {
-					const work = document.createElement("canvas");
-					work.width = src.width;
-					work.height = src.height;
-					const wctx = work.getContext("2d");
-					wctx.drawImage(src, 0, 0);
-					if (this.wm_enabled && this.wm_loaded && this.wm_img) {
-						this._composite_watermark_on_canvas(work, wctx);
-					}
-					if (this.show_comments && this.comments_enabled) {
-						this._composite_comments_on_canvas(work, wctx);
-					}
-					const final_canvas = (this.show_resize && this.resize_enabled)
-						? this._apply_output_shape(work)
-						: work;
-					this._preview_data_url = final_canvas.toDataURL("image/png");
-				} else {
-					this._preview_data_url = canvas.toDataURL("image/png");
-				}
-				this._preview_viewer_open = true;
-			} catch (e) {
-				console.error("preview viewer failed", e);
-			}
-		},
-
 		_schedule_preview_update() {
 			if (this._preview_debounce) clearTimeout(this._preview_debounce);
 			this._preview_debounce = setTimeout(() => {
@@ -1872,6 +1821,17 @@ export default {
 			pctx.drawImage(final_canvas, 0, 0, disp_w, disp_h);
 
 			this.preview_dims = { w: final_canvas.width, h: final_canvas.height };
+
+			// Refresh the <el-image> data URL from the same final_canvas
+			// so the click-to-enlarge viewer always shows current state.
+			try {
+				const fmt = (this.show_resize && this.resize_enabled && !this.resize_flatten_rgb)
+					? "image/png" : "image/jpeg";
+				this._preview_data_url = final_canvas.toDataURL(fmt, 0.88);
+			} catch (e) {
+				// toDataURL can throw on huge canvases; fall back to null
+				this._preview_data_url = null;
+			}
 		},
 
 		// Extract the watermark composite from crop_image() so _render_preview
@@ -2456,17 +2416,8 @@ img {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	cursor: zoom-in;
-	transition: opacity 0.15s ease;
-}
-.cropper-preview-thumb:hover { opacity: 0.92; }
-.cropper-preview-thumb:hover .cropper-preview-zoom { opacity: 1; }
-.cropper-preview-thumb canvas {
-	max-width: 100%;
-	max-height: 100%;
-	width: auto;
-	height: auto;
 	border: 1px solid var(--border-color);
+	border-radius: 6px;
 	background: #ffffff;
 	background-image:
 		linear-gradient(45deg, #f0f0f0 25%, transparent 25%),
@@ -2475,73 +2426,31 @@ img {
 		linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
 	background-size: 12px 12px;
 	background-position: 0 0, 0 6px, 6px -6px, -6px 0;
-	border-radius: 6px;
-	display: block;
+	overflow: hidden;
 }
-.cropper-preview-zoom {
-	position: absolute;
-	top: 8px;
-	right: 8px;
-	width: 28px;
-	height: 28px;
-	border-radius: 50%;
-	background: rgba(15, 23, 42, 0.72);
-	color: #fff;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	opacity: 0;
-	transition: opacity 0.15s ease;
-	pointer-events: none;   /* visual hint only, parent owns the click */
-}
-
-/* Lightbox overlay shown when user clicks the preview thumb. */
-.cropper-preview-viewer-host {
-	position: fixed;
-	inset: 0;
-	background: rgba(15, 23, 42, 0.82);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	z-index: 2050;  /* above Bootstrap modal (1055) */
-	padding: 40px;
-	cursor: zoom-out;
-}
-.cropper-preview-viewer-img {
+/* Fallback canvas shown until the <el-image> mounts its img (first
+   _render_preview populates _preview_data_url → el-image takes over). */
+.cropper-preview-thumb canvas {
 	max-width: 100%;
 	max-height: 100%;
+	width: auto;
+	height: auto;
+	display: block;
+}
+/* Hide the canvas once el-image has an src — el-image handles rendering
+   AND the zoom-viewer lifecycle, so showing both would double-draw. */
+.cropper-preview-thumb canvas.el-image-backed { display: none; }
+/* el-image fills the thumb container and provides its own preview
+   behaviour — preview-src-list spins up el-image-viewer on click. */
+.cropper-preview-elimage {
+	width: 100%;
+	height: 100%;
+	cursor: zoom-in;
+}
+.cropper-preview-elimage >>> .el-image__inner {
 	object-fit: contain;
-	border-radius: 6px;
-	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
-	background: #fff;
-	background-image:
-		linear-gradient(45deg, #f0f0f0 25%, transparent 25%),
-		linear-gradient(-45deg, #f0f0f0 25%, transparent 25%),
-		linear-gradient(45deg, transparent 75%, #f0f0f0 75%),
-		linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
-	background-size: 16px 16px;
-	cursor: default;
-}
-.cropper-preview-viewer-close {
-	position: absolute;
-	top: 20px;
-	right: 24px;
-	width: 40px;
-	height: 40px;
-	border-radius: 50%;
-	border: none;
-	background: rgba(255, 255, 255, 0.15);
-	color: #fff;
-	font-size: 28px;
-	line-height: 1;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	transition: background 0.15s ease;
-}
-.cropper-preview-viewer-close:hover {
-	background: rgba(255, 255, 255, 0.28);
+	width: 100%;
+	height: 100%;
 }
 .cropper-preview-chips {
 	margin-top: 6px;
@@ -3641,5 +3550,17 @@ img {
    modal-footer because they share the same .modal-content parent. */
 .modal-body.image-cropper-modal-body + .modal-footer {
 	display: none !important;
+}
+
+/* Element UI's <el-image> mounts its image-viewer lightbox at
+   document.body — it's not inside the Vue subtree so scoped styles
+   can't reach it. Bootstrap's modal uses z-index: 1055, so without
+   this bump the viewer opens UNDERNEATH the upload dialog and the
+   user can't interact with it. */
+.el-image-viewer__wrapper {
+	z-index: 2050 !important;
+}
+.el-image-viewer__mask {
+	z-index: 2049 !important;
 }
 </style>

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -109,6 +109,12 @@
 						<div class="comment-overlay-text" :style="comment_text_style(box)">
 							{{ box.text || __('(empty)') }}
 						</div>
+						<div
+							v-if="selected_comment_idx === i && interaction_mode === 'comment'"
+							class="comment-rotate-handle"
+							:title="__('Rotate')"
+							@mousedown.stop="on_comment_rotate_mousedown($event, i)"
+						>↻</div>
 					</div>
 				</div>
 				<div v-if="bg_processing" class="cropper-loading-overlay">
@@ -522,6 +528,14 @@
 										min="5" max="100" step="1"
 										:value="Math.round(box.width_pct)"
 										@input="_update_comment(i, 'width_pct', parseFloat($event.target.value) || 5)"
+									/>
+								</label>
+								<label class="comment-control">
+									<span>{{ __("Rotate °") }}</span>
+									<input type="number" class="wm-input comment-num-input"
+										min="-180" max="180" step="5"
+										:value="Math.round(box.rotation_deg || 0)"
+										@input="_update_comment(i, 'rotation_deg', parseFloat($event.target.value) || 0)"
 									/>
 								</label>
 							</div>
@@ -1299,14 +1313,19 @@ export default {
 			// Percentage-based position + size. Absolute inside the
 			// .comment-overlay container which is already sized to match
 			// the cropper image display rect.
+			// Rotation uses CSS transform around center to match the
+			// server-side PIL rotation (which also rotates around center).
 			const leftPct = (box.position_x_pct || 50) - (box.width_pct || 40) / 2;
 			const topPct = (box.position_y_pct || 50) - (box.height_pct || 10) / 2;
+			const rot = box.rotation_deg || 0;
 			return {
 				position: "absolute",
 				left: leftPct + "%",
 				top: topPct + "%",
 				width: (box.width_pct || 40) + "%",
 				height: (box.height_pct || 10) + "%",
+				transform: rot ? `rotate(${rot}deg)` : null,
+				transformOrigin: "50% 50%",
 			};
 		},
 		comment_text_style(box) {
@@ -1344,6 +1363,7 @@ export default {
 			this.comment_dragging_idx = i;
 			const box = this.comment_boxes[i];
 			this._comment_drag_start = {
+				mode: "move",
 				clientX: e.clientX,
 				clientY: e.clientY,
 				origXPct: box.position_x_pct,
@@ -1358,24 +1378,61 @@ export default {
 			this.comment_dragging_idx = i;
 			const box = this.comment_boxes[i];
 			this._comment_drag_start = {
+				mode: "move",
 				clientX: t.clientX,
 				clientY: t.clientY,
 				origXPct: box.position_x_pct,
 				origYPct: box.position_y_pct,
 			};
 		},
+		on_comment_rotate_mousedown(e, i) {
+			if (this.interaction_mode !== "comment") return;
+			const cd = this._canvas_data;
+			const wrapper = this.$refs.wrapper;
+			if (!cd || !wrapper) return;
+			this.selected_comment_idx = i;
+			this.comment_dragging_idx = i;
+			const box = this.comment_boxes[i];
+			// Box center in page pixels: wrapper origin + canvas offset + box center %
+			const wrapperRect = wrapper.getBoundingClientRect();
+			const cx = wrapperRect.left + cd.left + (box.position_x_pct / 100) * cd.width;
+			const cy = wrapperRect.top + cd.top + (box.position_y_pct / 100) * cd.height;
+			const startAngle = Math.atan2(e.clientY - cy, e.clientX - cx) * 180 / Math.PI;
+			this._comment_drag_start = {
+				mode: "rotate",
+				cx,
+				cy,
+				startAngle,
+				origRot: box.rotation_deg || 0,
+			};
+			e.preventDefault();
+		},
 		_on_comment_mousemove(e) {
 			if (this.comment_dragging_idx < 0 || !this._comment_drag_start) return;
+			const start = this._comment_drag_start;
+			const i = this.comment_dragging_idx;
+			const box = this.comment_boxes[i];
+			if (!box) return;
+
+			if (start.mode === "rotate") {
+				const currentAngle = Math.atan2(
+					e.clientY - start.cy,
+					e.clientX - start.cx
+				) * 180 / Math.PI;
+				let rot = start.origRot + (currentAngle - start.startAngle);
+				while (rot > 180) rot -= 360;
+				while (rot < -180) rot += 360;
+				if (e.shiftKey) rot = Math.round(rot / 15) * 15;
+				this.$set(this.comment_boxes, i, { ...box, rotation_deg: rot });
+				return;
+			}
+
 			const cd = this._canvas_data;
 			if (!cd) return;
-			const start = this._comment_drag_start;
 			const dx = e.clientX - start.clientX;
 			const dy = e.clientY - start.clientY;
 			const dxPct = (dx / cd.width) * 100;
 			const dyPct = (dy / cd.height) * 100;
-			const i = this.comment_dragging_idx;
-			const box = this.comment_boxes[i];
-			if (!box) return;
 			const newX = Math.max(0, Math.min(100, start.origXPct + dxPct));
 			const newY = Math.max(0, Math.min(100, start.origYPct + dyPct));
 			this.$set(this.comment_boxes, i, {
@@ -1388,6 +1445,7 @@ export default {
 			if (this.comment_dragging_idx >= 0) {
 				this.comment_dragging_idx = -1;
 				this._comment_drag_start = null;
+				this._schedule_preview_update();
 			}
 		},
 
@@ -1530,6 +1588,7 @@ export default {
 				const cx = w * (box.position_x_pct || 50) / 100;
 				const cy = h * (box.position_y_pct || 50) / 100;
 				const box_w_px = w * (box.width_pct || 40) / 100;
+				const rotation_deg = box.rotation_deg || 0;
 
 				// Simple greedy word-wrap (same intent as _wrap_to_width on server)
 				const lines = this._wrap_text_to_width(
@@ -1537,6 +1596,18 @@ export default {
 				);
 				const line_h = font_size_px * 1.2;
 				const total_h = lines.length * line_h;
+
+				// Rotate around box center (cx, cy). Matches CSS transform-origin 50% 50%
+				// on the overlay box and PIL's rotate(-angle, expand=True) + alpha_composite
+				// which keeps text centered on (cx, cy) after rotation.
+				const needs_rotate = Math.abs(rotation_deg) > 0.001;
+				if (needs_rotate) {
+					ctx.save();
+					ctx.translate(cx, cy);
+					ctx.rotate((rotation_deg * Math.PI) / 180);
+					ctx.translate(-cx, -cy);
+				}
+
 				let y_cursor = cy - total_h / 2 + line_h * 0.75;
 				for (const line of lines) {
 					const line_w = ctx.measureText(line).width;
@@ -1546,6 +1617,10 @@ export default {
 					else x = cx - line_w / 2;
 					ctx.fillText(line, x, y_cursor);
 					y_cursor += line_h;
+				}
+
+				if (needs_rotate) {
+					ctx.restore();
 				}
 			}
 		},
@@ -3039,6 +3114,29 @@ img {
 	white-space: pre-wrap;
 	overflow: hidden;
 	text-overflow: clip;
+}
+.comment-rotate-handle {
+	position: absolute;
+	top: -22px;
+	left: 50%;
+	margin-left: -9px;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	background: #10b981;
+	color: #fff;
+	font-size: 11px;
+	line-height: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: grab;
+	user-select: none;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+	z-index: 5;
+}
+.comment-rotate-handle:active {
+	cursor: grabbing;
 }
 
 /* Enhanced comment entry controls */

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -3067,10 +3067,23 @@ img {
 		grid-template-columns: 1fr;
 		grid-template-rows: auto auto auto;
 		height: auto;
+		min-height: auto;
 	}
-	.cropper-left-col { min-height: 0; }
+	.cropper-left-col {
+		min-height: auto;
+	}
+	/* Stacked layout: cropper stage needs a guaranteed minimum height
+	   so it stays usable on phones. 55vh is enough to fit a product
+	   photo with room to drag the crop box; we also enforce an
+	   absolute 400px floor so short viewports (≤720px tall) still get
+	   a workable canvas, and cap at 600px so mid-sized tablets don't
+	   get a cropper that dwarfs the controls below it. */
+	.cropper-image-stage {
+		min-height: max(400px, 55vh);
+		max-height: 600px;
+	}
 	.cropper-image-wrapper {
-		min-height: 50vh;
+		min-height: inherit;
 	}
 	.cropper-right-col {
 		max-height: none;
@@ -3087,9 +3100,13 @@ img {
 	.segmented-tab { padding: 7px 12px; font-size: 13px; }
 }
 @media (max-width: 480px) {
-	/* Very small phones — cropper still takes most of the viewport,
-	   preview thumb shrinks slightly to free toolbar width. */
-	.cropper-image-wrapper { min-height: 40vh; }
+	/* Very small phones — keep the same 400px floor as @900px so
+	   users aren't cropping in a tiny viewport. Cap tighter since
+	   phones have less vertical space overall. */
+	.cropper-image-stage {
+		min-height: max(400px, 50vh);
+		max-height: 520px;
+	}
 	.cropper-preview-canvas,
 	.cropper-preview-elimage,
 	.cropper-toolbar-preview-spinner {
@@ -4006,6 +4023,17 @@ img {
 	/* Remove the default modal-body bottom padding so the sticky action
 	   bar sits flush at the bottom edge with no visible gap. */
 	padding-bottom: 0 !important;
+}
+
+/* Narrow viewports: the cropper stage + param panel stack vertically,
+   and their combined height easily exceeds the available modal height.
+   Drop the modal-body's hard cap so the ENTIRE body scrolls together
+   (toolbar + stage + params + sticky bottom bar), instead of trying to
+   fit everything and squeezing the stage into a 60px sliver. */
+@media (max-width: 900px) {
+	.modal-body.image-cropper-modal-body {
+		max-height: none;
+	}
 }
 
 /* Hide the dialog's built-in footer (Set all private / Upload) while the

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1,592 +1,614 @@
 <template>
-	<div>
-		<!-- Interaction-mode switcher: shown when multiple drag targets exist
-		     (watermark Corner OR comments enabled). Lets the user pick which
-		     overlay they're dragging. -->
-		<div
-			v-if="(show_watermark && wm_enabled && wm_loaded && wm_mode === 'Corner') || (show_comments && comments_enabled && comment_boxes.length > 0)"
-			class="interaction-switcher"
-		>
-			<span class="interaction-switcher-label">{{ __("Drag on image") }}</span>
-			<div class="segmented-tabs" role="tablist">
-				<button
-					class="segmented-tab"
-					:class="{ active: interaction_mode === 'crop' }"
-					role="tab"
-					:aria-selected="interaction_mode === 'crop'"
-					:title="__('Drag to resize/move the crop box')"
-					@click="set_mode('crop')"
-				>
-					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 2v14a2 2 0 002 2h14"/><path d="M18 22V8a2 2 0 00-2-2H2"/></svg>
-					{{ __("Crop box") }}
-				</button>
-				<button
-					v-if="show_watermark && wm_enabled && wm_loaded && wm_mode === 'Corner'"
-					class="segmented-tab"
-					:class="{ active: interaction_mode === 'watermark' }"
-					role="tab"
-					:aria-selected="interaction_mode === 'watermark'"
-					:title="__('Drag to move the watermark logo')"
-					@click="set_mode('watermark')"
-				>
-					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
-					{{ __("Watermark") }}
-				</button>
-				<button
-					v-if="show_comments && comments_enabled && comment_boxes.length > 0"
-					class="segmented-tab"
-					:class="{ active: interaction_mode === 'comment' }"
-					role="tab"
-					:aria-selected="interaction_mode === 'comment'"
-					:title="__('Drag to move text comments')"
-					@click="set_mode('comment')"
-				>
-					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-						<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-					</svg>
-					{{ __("Comment") }}
-				</button>
-			</div>
-		</div>
-
-		<div
-			class="cropper-image-wrapper"
-			ref="wrapper"
-			:class="{
-				'wm-mode': interaction_mode === 'watermark' && wm_mode === 'Corner',
-				'comment-mode': interaction_mode === 'comment',
-				'bg-processing': bg_processing,
-			}"
-			@mousedown="on_wrapper_mousedown"
-			@wheel.prevent="on_wrapper_wheel"
-			@touchstart="on_wrapper_touchstart"
-		>
-			<img ref="image" :src="src" :alt="file.name" />
-			<canvas
-				v-if="wm_enabled && wm_loaded"
-				ref="wm_canvas"
-				class="watermark-overlay-canvas"
-				:style="{ pointerEvents: (interaction_mode === 'watermark' && wm_mode === 'Corner') ? 'auto' : 'none' }"
-			></canvas>
-			<!-- Comment overlay: DOM boxes drawn on top of the image so user
-			     can see text positioning + drag them. Uses CropperJS image
-			     data to convert percentages → screen pixels. -->
-			<div
-				v-if="show_comments && comments_enabled"
-				class="comment-overlay"
-				:style="comment_overlay_style"
-			>
-				<div
-					v-for="(box, i) in comment_boxes"
-					:key="'overlay-box-' + i"
-					class="comment-overlay-box"
-					:class="{
-						selected: selected_comment_idx === i,
-						dragging: comment_dragging_idx === i,
-					}"
-					:style="comment_box_style(box)"
-					:data-box-idx="i"
-					@mousedown.stop="on_comment_mousedown($event, i)"
-					@touchstart.stop="on_comment_touchstart($event, i)"
-				>
-					<div class="comment-overlay-text" :style="comment_text_style(box)">
-						{{ box.text || __('(empty)') }}
-					</div>
-				</div>
-			</div>
-			<div v-if="bg_processing" class="cropper-loading-overlay">
-				<div class="cropper-spinner"></div>
-				<div class="cropper-loading-text">{{ __("Removing background...") }}</div>
-			</div>
-		</div>
-
-		<!-- ─── Unified Image Adjustments panel ───
-		     Both Remove BG auto-crop padding and Watermark knobs share a single
-		     panel so the dialog stays compact. The top toggles (Remove BG /
-		     Watermark) live in the sticky dialog footer; this panel only hosts
-		     the parameters for whichever features are currently on. -->
-		<div
-			v-if="(show_remove_bg && bg_removed && nobg_bbox) || (show_watermark && wm_enabled) || (show_resize && resize_enabled) || (show_comments && comments_enabled)"
-			class="adjustments-panel"
-		>
-			<!-- Live preview of the final output (what Crop will produce).
-			     Re-renders on any param change via the preview_tick
-			     reactive dependency so the user sees the resize +
-			     watermark + flatten result before committing. -->
-			<div
-				v-if="show_resize && resize_enabled"
-				class="adjustments-row adjustments-row-preview"
-			>
-				<label class="adjustments-field-label">
-					{{ __("Preview") }}
-					<span class="adjustments-field-hint">
-						{{ __("Final output after Crop") }}
-					</span>
-				</label>
-				<div class="resize-preview-wrap">
-					<canvas ref="preview_canvas" class="resize-preview-canvas"></canvas>
-					<div v-if="preview_dims" class="resize-preview-dims">
-						{{ preview_dims.w }}×{{ preview_dims.h }}
-					</div>
-				</div>
-			</div>
-
-			<!-- Resize (FIRST in list per UX spec) — aspect, mode, fill,
-			     flatten. Only shown when the Resize toggle pill is on. -->
-			<div
-				v-if="show_resize && resize_enabled"
-				class="adjustments-row adjustments-row-resize"
-			>
-				<label class="adjustments-field-label">
-					{{ __("Resize") }}
-					<span class="adjustments-field-hint">
-						{{ __("Aspect normalization baked on Crop. Never upscales.") }}
-					</span>
-				</label>
-				<div class="resize-tabs-row">
-					<span class="resize-sublabel">{{ __("Aspect") }}</span>
+	<div class="cropper-grid">
+		<!-- LEFT COLUMN: toolbar + cropper + preview + action buttons -->
+		<div class="cropper-left-col">
+			<!-- Top toolbar: Drag mode (crop/watermark/comment) + Crop ratio.
+			     Wraps to 2 rows on narrow screens. -->
+			<div class="cropper-top-toolbar">
+				<div class="cropper-toolbar-group" v-if="show_drag_mode_tabs">
+					<span class="cropper-toolbar-label">{{ __("Drag") }}:</span>
 					<div class="segmented-tabs" role="tablist">
 						<button
-							v-for="a in aspect_ratio_options"
-							:key="a"
 							class="segmented-tab"
-							:class="{ active: resize_aspect === a }"
-							@click="resize_aspect = a"
-						>{{ a }}</button>
-					</div>
-				</div>
-				<div class="resize-tabs-row">
-					<span class="resize-sublabel">{{ __("Mode") }}</span>
-					<div class="segmented-tabs" role="tablist">
-						<button
-							v-for="m in resize_mode_options"
-							:key="m"
-							class="segmented-tab"
-							:class="{ active: resize_mode === m, disabled: resize_aspect === 'Free' }"
-							:disabled="resize_aspect === 'Free'"
-							@click="resize_mode = m"
-						>{{ __(m) }}</button>
-					</div>
-				</div>
-				<div class="resize-misc-row">
-					<label class="resize-inline-toggle">
-						<input type="checkbox" v-model="resize_flatten_rgb" />
-						<span>{{ __("Solid background") }}</span>
-					</label>
-					<label
-						v-if="resize_flatten_rgb"
-						class="resize-inline-field"
-					>
-						<span>{{ __("Background color") }}</span>
-						<input
-							type="color"
-							class="resize-color"
-							v-model="resize_fill_color"
-						/>
-					</label>
-					<span
-						v-if="!resize_flatten_rgb"
-						class="resize-hint"
-					>
-						{{ __("Transparent background (PNG)") }}
-					</span>
-				</div>
-			</div>
-
-			<!-- Comments (new 2026-04) — simple list editor for single-item
-			     upload. Each entry is a text overlay with position/size/font
-			     controls. No drag UI here (use Item Image Batch for that).
-			     Baked into the Canvas composite on Crop click. -->
-			<div
-				v-if="show_comments && comments_enabled"
-				class="adjustments-row adjustments-row-comments"
-			>
-				<label class="adjustments-field-label">
-					{{ __("Comments") }}
-					<span class="adjustments-field-hint">
-						{{ __("Text baked into the image on Crop.") }}
-					</span>
-				</label>
-
-				<div v-if="comment_boxes.length === 0" class="comments-empty-hint">
-					{{ __("No comments yet.") }}
-				</div>
-
-				<div
-					v-for="(box, i) in comment_boxes"
-					:key="'box-' + i"
-					class="comment-entry"
-					:class="{ 'comment-entry-selected': selected_comment_idx === i }"
-					@click="selected_comment_idx = i"
-				>
-					<div class="comment-entry-header">
-						<span class="comment-entry-idx">#{{ i + 1 }}</span>
-						<textarea
-							class="comment-text-input"
-							:value="box.text"
-							:placeholder="__('Text…')"
-							rows="1"
-							@input="_update_comment(i, 'text', $event.target.value)"
-						></textarea>
-						<button
-							type="button"
-							class="btn btn-xs btn-danger comment-delete"
-							:title="__('Delete comment')"
-							@click.stop="_delete_comment(i)"
-						>×</button>
-					</div>
-
-					<!-- Row 1: Font family + Size + style toggles -->
-					<div class="comment-entry-controls">
-						<label class="comment-control comment-control-wide">
-							<span>{{ __("Font") }}</span>
-							<select class="wm-input comment-font-select"
-								:value="box.font_family"
-								@change="_update_comment(i, 'font_family', $event.target.value)"
-							>
-								<option v-for="f in comment_font_families" :key="f" :value="f">{{ f }}</option>
-							</select>
-						</label>
-						<label class="comment-control">
-							<span>{{ __("Size %") }}</span>
-							<input type="number" class="wm-input comment-num-input"
-								min="1" max="50" step="0.5"
-								:value="box.font_size_pct"
-								@input="_update_comment(i, 'font_size_pct', parseFloat($event.target.value) || 5.0)"
-							/>
-						</label>
-						<button
-							type="button"
-							class="comment-style-btn"
-							:class="{ active: box.font_weight === 'Bold' }"
-							:title="__('Bold')"
-							@click="_update_comment(i, 'font_weight', box.font_weight === 'Bold' ? 'Normal' : 'Bold')"
-						><strong>B</strong></button>
-						<button
-							type="button"
-							class="comment-style-btn"
-							:class="{ active: box.font_style === 'Italic' }"
-							:title="__('Italic')"
-							@click="_update_comment(i, 'font_style', box.font_style === 'Italic' ? 'Normal' : 'Italic')"
-						><em>I</em></button>
-						<input type="color" class="comment-color-input"
-							:title="__('Text color')"
-							:value="box.color"
-							@input="_update_comment(i, 'color', $event.target.value)"
-						/>
-					</div>
-
-					<!-- Row 2: Alignment + position -->
-					<div class="comment-entry-controls">
-						<div class="comment-align-group">
-							<button
-								v-for="a in ['Left', 'Center', 'Right']"
-								:key="'align-' + a"
-								type="button"
-								class="comment-align-btn"
-								:class="{ active: box.align === a }"
-								:title="__(a)"
-								@click="_update_comment(i, 'align', a)"
-							>{{ a.charAt(0) }}</button>
-						</div>
-						<label class="comment-control">
-							<span>X%</span>
-							<input type="number" class="wm-input comment-num-input"
-								min="0" max="100" step="1"
-								:value="Math.round(box.position_x_pct)"
-								@input="_update_comment(i, 'position_x_pct', parseFloat($event.target.value) || 0)"
-							/>
-						</label>
-						<label class="comment-control">
-							<span>Y%</span>
-							<input type="number" class="wm-input comment-num-input"
-								min="0" max="100" step="1"
-								:value="Math.round(box.position_y_pct)"
-								@input="_update_comment(i, 'position_y_pct', parseFloat($event.target.value) || 0)"
-							/>
-						</label>
-						<label class="comment-control">
-							<span>W%</span>
-							<input type="number" class="wm-input comment-num-input"
-								min="5" max="100" step="1"
-								:value="Math.round(box.width_pct)"
-								@input="_update_comment(i, 'width_pct', parseFloat($event.target.value) || 5)"
-							/>
-						</label>
-					</div>
-				</div>
-
-				<div class="comments-actions">
-					<button type="button" class="btn btn-xs btn-primary-light" @click="_add_comment()">
-						+ {{ __("Add Comment") }}
-					</button>
-					<button
-						v-if="comment_presets && comment_presets.length"
-						type="button"
-						class="btn btn-xs btn-default"
-						@click="_toggle_preset_menu()"
-					>
-						📋 {{ __("Presets") }}
-					</button>
-					<div v-if="preset_menu_open" class="comment-preset-menu">
-						<div
-							v-for="(p, pi) in comment_presets"
-							:key="'preset-' + pi"
-							class="comment-preset-item"
-							@click="_insert_preset(p)"
+							:class="{ active: interaction_mode === 'crop' }"
+							role="tab"
+							:aria-selected="interaction_mode === 'crop'"
+							:title="__('Drag to resize/move the crop box')"
+							@click="set_mode('crop')"
 						>
-							{{ p.text || __("(no text)") }}
-						</div>
+							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 2v14a2 2 0 002 2h14"/><path d="M18 22V8a2 2 0 00-2-2H2"/></svg>
+							{{ __("Crop box") }}
+						</button>
+						<button
+							v-if="show_watermark && wm_enabled && wm_loaded && wm_mode === 'Corner'"
+							class="segmented-tab"
+							:class="{ active: interaction_mode === 'watermark' }"
+							role="tab"
+							:aria-selected="interaction_mode === 'watermark'"
+							:title="__('Drag to move the watermark logo')"
+							@click="set_mode('watermark')"
+						>
+							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+							{{ __("Watermark") }}
+						</button>
+						<button
+							v-if="show_comments && comments_enabled && comment_boxes.length > 0"
+							class="segmented-tab"
+							:class="{ active: interaction_mode === 'comment' }"
+							role="tab"
+							:aria-selected="interaction_mode === 'comment'"
+							:title="__('Drag to move text comments')"
+							@click="set_mode('comment')"
+						>
+							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+							{{ __("Comment") }}
+						</button>
 					</div>
 				</div>
-
-				<div class="wm-panel-actions">
-					<button class="btn btn-xs btn-default" @click="_reset_comments_to_defaults">
-						{{ __("Reset") }}
-					</button>
-					<button class="btn btn-xs btn-primary-light" @click="_save_comment_defaults">
-						{{ __("Save Style as Default") }}
-					</button>
+				<div class="cropper-toolbar-group" v-if="fixed_aspect_ratio == null">
+					<span class="cropper-toolbar-label">{{ __("Crop ratio") }}:</span>
+					<div class="btn-group btn-group-sm">
+						<button
+							v-for="button in aspect_ratio_buttons"
+							type="button"
+							class="btn btn-default btn-sm"
+							:class="{
+								active: isNaN(aspect_ratio)
+									? isNaN(button.value)
+									: button.value === aspect_ratio,
+							}"
+							:key="button.label"
+							@click="aspect_ratio = button.value"
+						>
+							{{ button.label }}
+						</button>
+					</div>
 				</div>
 			</div>
 
-			<!-- Auto-crop padding (Remove BG) — only shown when Remove BG is on
-			     AND a bbox is available. -->
+			<!-- Cropper canvas — main image with all overlays -->
 			<div
-				v-if="show_remove_bg && bg_removed && nobg_bbox"
-				class="adjustments-row"
+				class="cropper-image-wrapper"
+				ref="wrapper"
+				:class="{
+					'wm-mode': interaction_mode === 'watermark' && wm_mode === 'Corner',
+					'comment-mode': interaction_mode === 'comment',
+					'bg-processing': bg_processing,
+				}"
+				@mousedown="on_wrapper_mousedown"
+				@wheel.prevent="on_wrapper_wheel"
+				@touchstart="on_wrapper_touchstart"
 			>
-				<label class="adjustments-field-label">
-					{{ __("Auto-crop padding") }}
-				</label>
-				<div class="padding-input-row">
-					<input
-						type="range"
-						class="wm-slider"
-						min="-20" max="40" step="1"
-						:value="effective_padding_pct"
-						@input="set_padding_pct(parseInt($event.target.value))"
-					/>
-					<div class="wm-input-group padding-input-group">
-						<input
-							type="number"
-							class="wm-input"
-							min="-20" max="40" step="1"
-							:value="effective_padding_pct"
-							@input="set_padding_pct(parseInt($event.target.value))"
-						/>
-						<span class="wm-input-suffix">%</span>
+				<img ref="image" :src="src" :alt="file.name" />
+				<canvas
+					v-if="wm_enabled && wm_loaded"
+					ref="wm_canvas"
+					class="watermark-overlay-canvas"
+					:style="{ pointerEvents: (interaction_mode === 'watermark' && wm_mode === 'Corner') ? 'auto' : 'none' }"
+				></canvas>
+				<!-- Comment overlay: DOM boxes drawn on top of the image so
+				     the user can see text positioning + drag them. -->
+				<div
+					v-if="show_comments && comments_enabled"
+					class="comment-overlay"
+					:style="comment_overlay_style"
+				>
+					<div
+						v-for="(box, i) in comment_boxes"
+						:key="'overlay-box-' + i"
+						class="comment-overlay-box"
+						:class="{
+							selected: selected_comment_idx === i,
+							dragging: comment_dragging_idx === i,
+						}"
+						:style="comment_box_style(box)"
+						:data-box-idx="i"
+						@mousedown.stop="on_comment_mousedown($event, i)"
+						@touchstart.stop="on_comment_touchstart($event, i)"
+					>
+						<div class="comment-overlay-text" :style="comment_text_style(box)">
+							{{ box.text || __('(empty)') }}
+						</div>
 					</div>
 				</div>
-				<div class="wm-panel-actions">
-					<button class="btn btn-xs btn-default" @click="reset_padding_pct">
-						{{ __("Reset") }}
-					</button>
-					<button class="btn btn-xs btn-primary-light" @click="save_padding_default">
-						{{ __("Save as Default") }}
-					</button>
+				<div v-if="bg_processing" class="cropper-loading-overlay">
+					<div class="cropper-spinner"></div>
+					<div class="cropper-loading-text">{{ __("Removing background...") }}</div>
 				</div>
 			</div>
-			<div
-				v-else-if="show_remove_bg && bg_removed && !nobg_bbox"
-				class="adjustments-row adjustments-warn"
-			>
-				{{ __("Auto-crop not available — microservice did not return a bounding box.") }}
+
+			<!-- Preview strip: live thumbnail + chip summary of what's on -->
+			<div class="cropper-preview-bar" v-if="any_feature_on">
+				<div class="cropper-preview-thumb">
+					<canvas ref="preview_canvas" class="resize-preview-canvas"></canvas>
+					<div v-if="preview_dims" class="cropper-preview-dims">
+						{{ preview_dims.w }} × {{ preview_dims.h }} {{ preview_format_label }}
+					</div>
+				</div>
+				<div class="cropper-preview-body">
+					<div class="cropper-preview-title">
+						{{ __("Preview") }}
+						<span class="cropper-preview-hint">{{ __("final output after Crop") }}</span>
+					</div>
+					<div class="cropper-preview-chips">
+						<span v-if="show_remove_bg && bg_removed" class="cropper-preview-chip">{{ __("Remove BG") }}</span>
+						<span v-if="show_watermark && wm_enabled" class="cropper-preview-chip">
+							{{ __("Watermark") }} · {{ wm_mode === "Tiled" ? __("Tiled") : __("Corner") }}
+						</span>
+						<span v-if="show_comments && comments_enabled && comment_boxes.length" class="cropper-preview-chip">
+							{{ __("Comments") }} · {{ comment_boxes.length }}
+						</span>
+						<span v-if="show_resize && resize_enabled" class="cropper-preview-chip">
+							{{ __("Canvas") }} · {{ resize_aspect }}
+						</span>
+					</div>
+				</div>
 			</div>
 
-			<!-- Watermark controls — only shown when Watermark is on. -->
-			<div v-if="show_watermark && wm_enabled" class="adjustments-row adjustments-row-wm">
-				<!-- Segmented tab control: Tiled first, Corner second. -->
-				<div class="segmented-tabs" role="tablist">
+			<!-- Bottom action row: Back / Crop -->
+			<div class="image-cropper-actions" ref="actions">
+				<div><!-- spacer for flex layout; no left actions --></div>
+				<div>
 					<button
-						class="segmented-tab"
-						:class="{ active: wm_mode === 'Tiled' }"
-						role="tab"
-						:aria-selected="wm_mode === 'Tiled'"
-						:title="__('Tiled — covers the whole image, not draggable')"
-						@click="wm_set_mode('Tiled')"
+						class="btn btn-sm margin-right"
+						@click="$emit('toggle_image_cropper')"
+						v-if="fixed_aspect_ratio == null"
 					>
-						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-						{{ __("Tiled") }}
+						{{ __("Back") }}
 					</button>
-					<button
-						class="segmented-tab"
-						:class="{ active: wm_mode === 'Corner' }"
-						role="tab"
-						:aria-selected="wm_mode === 'Corner'"
-						:title="__('Corner — single logo at a fixed position, draggable')"
-						@click="wm_set_mode('Corner')"
-					>
-						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L12 12"/><rect x="2" y="14" width="10" height="8" rx="1"/></svg>
-						{{ __("Corner") }}
-					</button>
-				</div>
-
-				<!-- Tiled mode controls -->
-				<template v-if="wm_mode === 'Tiled'">
-					<div class="wm-sliders-row">
-						<div class="wm-slider-field">
-							<label class="wm-control-label">{{ __("Opacity") }}</label>
-							<input type="range" class="wm-slider" min="5" max="100"
-								:value="wm_tile_opacity" @input="wm_set_tile_opacity(parseInt($event.target.value))" />
-							<span class="wm-slider-value">{{ wm_tile_opacity }}%</span>
-						</div>
-						<div class="wm-slider-field">
-							<label class="wm-control-label">{{ __("Tile Size") }}</label>
-							<input type="range" class="wm-slider" min="3" max="80"
-								:value="wm_tile_size" @input="wm_set_tile_size(parseInt($event.target.value))" />
-							<span class="wm-slider-value">{{ Math.round(wm_tile_size) }}%</span>
-						</div>
-						<div class="wm-slider-field">
-							<label class="wm-control-label">{{ __("Rotation") }}</label>
-							<input type="range" class="wm-slider" min="-180" max="180"
-								:value="wm_tile_rotation" @input="wm_set_tile_rotation(parseInt($event.target.value))" />
-							<span class="wm-slider-value">{{ wm_tile_rotation }}°</span>
-						</div>
-						<div class="wm-slider-field">
-							<label class="wm-control-label">{{ __("Spacing") }}</label>
-							<input type="range" class="wm-slider" min="0" max="100"
-								:value="wm_tile_spacing" @input="wm_set_tile_spacing(parseInt($event.target.value))" />
-							<span class="wm-slider-value">{{ wm_tile_spacing }}%</span>
-						</div>
-					</div>
-				</template>
-
-				<!-- Corner mode controls -->
-				<template v-if="wm_mode === 'Corner'">
-					<div class="wm-sliders-row">
-						<div class="wm-slider-field">
-							<label class="wm-control-label">{{ __("Opacity") }}</label>
-							<input type="range" class="wm-slider" min="5" max="100"
-								:value="wm_opacity" @input="wm_set_opacity(parseInt($event.target.value))" />
-							<span class="wm-slider-value">{{ wm_opacity }}%</span>
-						</div>
-						<div class="wm-slider-field">
-							<label class="wm-control-label">{{ __("Size") }}</label>
-							<input type="range" class="wm-slider" min="5" max="100"
-								:value="wm_size" @input="wm_set_size(parseFloat($event.target.value))" />
-							<span class="wm-slider-value">{{ Math.round(wm_size) }}%</span>
-						</div>
-						<div class="wm-slider-field">
-							<label class="wm-control-label">{{ __("Position X") }}</label>
-							<input type="range" class="wm-slider" min="0" max="100"
-								:value="wm_pos_x" @input="wm_set_pos_x(parseFloat($event.target.value))" />
-							<span class="wm-slider-value">{{ Math.round(wm_pos_x) }}%</span>
-						</div>
-						<div class="wm-slider-field">
-							<label class="wm-control-label">{{ __("Position Y") }}</label>
-							<input type="range" class="wm-slider" min="0" max="100"
-								:value="wm_pos_y" @input="wm_set_pos_y(parseFloat($event.target.value))" />
-							<span class="wm-slider-value">{{ Math.round(wm_pos_y) }}%</span>
-						</div>
-					</div>
-				</template>
-
-				<div class="wm-panel-actions">
-					<button class="btn btn-xs btn-default" @click="wm_reset_defaults">
-						{{ __("Reset") }}
-					</button>
-					<button class="btn btn-xs btn-primary-light" @click="wm_save_defaults">
-						{{ __("Save as Default") }}
+					<button class="btn btn-primary btn-sm" :disabled="bg_processing" @click="crop_image">
+						{{ __("Crop") }}
 					</button>
 				</div>
 			</div>
 		</div>
 
-		<div class="image-cropper-actions" ref="actions">
-			<div class="cropper-left-actions">
-				<div class="btn-group" v-if="fixed_aspect_ratio == null">
-					<button
-						v-for="button in aspect_ratio_buttons"
-						type="button"
-						class="btn btn-default btn-sm"
-						:class="{
-							active: isNaN(aspect_ratio)
-								? isNaN(button.value)
-								: button.value === aspect_ratio,
-						}"
-						:key="button.label"
-						@click="aspect_ratio = button.value"
-					>
-						{{ button.label }}
-					</button>
-				</div>
-				<div
-					v-if="show_remove_bg"
-					class="toggle-pill"
-					:class="{ active: bg_removed, processing: bg_processing }"
-					@click="toggle_remove_bg"
-				>
-					<span class="toggle-pill-label">{{ __("Remove BG") }}</span>
-					<span class="toggle-pill-switch">
-						<span class="toggle-pill-track" :class="{ on: bg_removed }">
-							<span class="toggle-pill-thumb"></span>
-						</span>
-					</span>
-				</div>
-				<div
-					v-if="show_watermark"
-					class="toggle-pill"
-					:class="{ active: wm_enabled }"
-					@click="toggle_watermark"
-				>
-					<span class="toggle-pill-label">{{ __("Watermark") }}</span>
-					<span class="toggle-pill-switch">
-						<span class="toggle-pill-track" :class="{ on: wm_enabled }">
-							<span class="toggle-pill-thumb"></span>
-						</span>
-					</span>
-				</div>
-				<div
-					v-if="show_resize"
-					class="toggle-pill"
-					:class="{ active: resize_enabled }"
-					@click="resize_enabled = !resize_enabled"
-					:title="__('Normalize output aspect ({0}, {1})', [resize_aspect, resize_mode])"
-				>
-					<span class="toggle-pill-label">
-						{{ __("Resize") }}
-						<span v-if="resize_enabled" class="toggle-pill-sublabel">
-							{{ resize_aspect }}
-						</span>
-					</span>
-					<span class="toggle-pill-switch">
-						<span class="toggle-pill-track" :class="{ on: resize_enabled }">
-							<span class="toggle-pill-thumb"></span>
-						</span>
-					</span>
-				</div>
-				<div
-					v-if="show_comments"
-					class="toggle-pill"
-					:class="{ active: comments_enabled }"
-					@click="comments_enabled = !comments_enabled"
-					:title="__('Add text comments baked into the image')"
-				>
-					<span class="toggle-pill-label">
-						{{ __("Comments") }}
-						<span v-if="comments_enabled && comment_boxes.length > 0" class="toggle-pill-sublabel">
-							{{ comment_boxes.length }}
-						</span>
-					</span>
-					<span class="toggle-pill-switch">
-						<span class="toggle-pill-track" :class="{ on: comments_enabled }">
-							<span class="toggle-pill-thumb"></span>
-						</span>
-					</span>
-				</div>
-			</div>
-			<div>
+		<!-- RIGHT COLUMN: tabbed feature panel -->
+		<div class="cropper-right-col" v-if="any_feature_shown">
+			<div class="cropper-feature-tabs">
 				<button
-					class="btn btn-sm margin-right"
-					@click="$emit('toggle_image_cropper')"
-					v-if="fixed_aspect_ratio == null"
+					v-if="show_remove_bg"
+					type="button"
+					class="cropper-feature-tab"
+					:class="{ active: active_tab === 'remove_bg' }"
+					@click="active_tab = 'remove_bg'"
 				>
-					{{ __("Back") }}
+					<span class="cropper-feature-tab-label">{{ __("Remove BG") }}</span>
+					<span class="cropper-feature-tab-state" :class="bg_removed ? 'on' : 'off'">
+						<span class="cropper-feature-tab-dot"></span>
+						{{ bg_removed ? __("on") : __("off") }}
+					</span>
 				</button>
-				<button class="btn btn-primary btn-sm" :disabled="bg_processing" @click="crop_image">
-					{{ __("Crop") }}
+				<button
+					v-if="show_watermark"
+					type="button"
+					class="cropper-feature-tab"
+					:class="{ active: active_tab === 'watermark' }"
+					@click="active_tab = 'watermark'"
+				>
+					<span class="cropper-feature-tab-label">{{ __("Watermark") }}</span>
+					<span class="cropper-feature-tab-state" :class="wm_enabled ? 'on' : 'off'">
+						<span class="cropper-feature-tab-dot"></span>
+						{{ wm_enabled ? __("on") : __("off") }}
+					</span>
 				</button>
+				<button
+					v-if="show_comments"
+					type="button"
+					class="cropper-feature-tab"
+					:class="{ active: active_tab === 'comments' }"
+					@click="active_tab = 'comments'"
+				>
+					<span class="cropper-feature-tab-label">{{ __("Comments") }}</span>
+					<span class="cropper-feature-tab-state" :class="comments_enabled ? 'on' : 'off'">
+						<span class="cropper-feature-tab-dot"></span>
+						{{ comments_enabled ? __("on") : __("off") }}
+					</span>
+				</button>
+				<button
+					v-if="show_resize"
+					type="button"
+					class="cropper-feature-tab"
+					:class="{ active: active_tab === 'canvas' }"
+					@click="active_tab = 'canvas'"
+				>
+					<span class="cropper-feature-tab-label">{{ __("Canvas") }}</span>
+					<span class="cropper-feature-tab-state" :class="resize_enabled ? 'on' : 'off'">
+						<span class="cropper-feature-tab-dot"></span>
+						{{ resize_enabled ? __("on") : __("off") }}
+					</span>
+				</button>
+			</div>
+
+			<div class="cropper-tab-body">
+				<!-- REMOVE BG TAB -->
+				<div v-show="active_tab === 'remove_bg'" class="cropper-tab-pane">
+					<div class="cropper-tab-enable">
+						<span class="cropper-tab-enable-label">{{ __("Enable Remove Background") }}</span>
+						<div
+							class="toggle-pill toggle-pill-compact"
+							:class="{ active: bg_removed, processing: bg_processing }"
+							@click="toggle_remove_bg"
+						>
+							<span class="toggle-pill-switch">
+								<span class="toggle-pill-track" :class="{ on: bg_removed }">
+									<span class="toggle-pill-thumb"></span>
+								</span>
+							</span>
+						</div>
+					</div>
+					<div v-if="bg_removed && nobg_bbox" class="adjustments-row">
+						<label class="adjustments-field-label">{{ __("Auto-crop padding") }}</label>
+						<div class="padding-input-row">
+							<input
+								type="range" class="wm-slider"
+								min="-20" max="40" step="1"
+								:value="effective_padding_pct"
+								@input="set_padding_pct(parseInt($event.target.value))"
+							/>
+							<div class="wm-input-group padding-input-group">
+								<input
+									type="number" class="wm-input"
+									min="-20" max="40" step="1"
+									:value="effective_padding_pct"
+									@input="set_padding_pct(parseInt($event.target.value))"
+								/>
+								<span class="wm-input-suffix">%</span>
+							</div>
+						</div>
+						<div class="wm-panel-actions">
+							<button class="btn btn-xs btn-default" @click="reset_padding_pct">{{ __("Reset") }}</button>
+							<button class="btn btn-xs btn-primary-light" @click="save_padding_default">{{ __("Save as Default") }}</button>
+						</div>
+					</div>
+					<div v-else-if="bg_removed && !nobg_bbox" class="adjustments-row adjustments-warn">
+						{{ __("Auto-crop not available — microservice did not return a bounding box.") }}
+					</div>
+				</div>
+
+				<!-- WATERMARK TAB -->
+				<div v-show="active_tab === 'watermark'" class="cropper-tab-pane">
+					<div class="cropper-tab-enable">
+						<span class="cropper-tab-enable-label">{{ __("Enable Watermark") }}</span>
+						<div
+							class="toggle-pill toggle-pill-compact"
+							:class="{ active: wm_enabled }"
+							@click="toggle_watermark"
+						>
+							<span class="toggle-pill-switch">
+								<span class="toggle-pill-track" :class="{ on: wm_enabled }">
+									<span class="toggle-pill-thumb"></span>
+								</span>
+							</span>
+						</div>
+					</div>
+					<div v-if="wm_enabled" class="adjustments-row adjustments-row-wm">
+						<div class="segmented-tabs" role="tablist">
+							<button
+								class="segmented-tab"
+								:class="{ active: wm_mode === 'Tiled' }"
+								role="tab"
+								:aria-selected="wm_mode === 'Tiled'"
+								:title="__('Tiled — covers the whole image, not draggable')"
+								@click="wm_set_mode('Tiled')"
+							>
+								<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+								{{ __("Tiled") }}
+							</button>
+							<button
+								class="segmented-tab"
+								:class="{ active: wm_mode === 'Corner' }"
+								role="tab"
+								:aria-selected="wm_mode === 'Corner'"
+								:title="__('Corner — single logo at a fixed position, draggable')"
+								@click="wm_set_mode('Corner')"
+							>
+								<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L12 12"/><rect x="2" y="14" width="10" height="8" rx="1"/></svg>
+								{{ __("Corner") }}
+							</button>
+						</div>
+
+						<template v-if="wm_mode === 'Tiled'">
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Opacity") }}</label>
+								<input type="range" class="wm-slider" min="5" max="100"
+									:value="wm_tile_opacity"
+									@input="wm_tile_opacity = parseInt($event.target.value)" />
+								<span class="wm-slider-value">{{ wm_tile_opacity }}%</span>
+							</div>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Tile Size") }}</label>
+								<input type="range" class="wm-slider" min="5" max="80"
+									:value="wm_tile_size"
+									@input="wm_tile_size = parseFloat($event.target.value)" />
+								<span class="wm-slider-value">{{ Math.round(wm_tile_size) }}%</span>
+							</div>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Rotation") }}</label>
+								<input type="range" class="wm-slider" min="-180" max="180"
+									:value="wm_tile_rotation"
+									@input="wm_tile_rotation = parseInt($event.target.value)" />
+								<span class="wm-slider-value">{{ wm_tile_rotation }}°</span>
+							</div>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Spacing") }}</label>
+								<input type="range" class="wm-slider" min="0" max="100"
+									:value="wm_tile_spacing"
+									@input="wm_tile_spacing = parseInt($event.target.value)" />
+								<span class="wm-slider-value">{{ wm_tile_spacing }}%</span>
+							</div>
+						</template>
+
+						<template v-else>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Opacity") }}</label>
+								<input type="range" class="wm-slider" min="5" max="100"
+									:value="wm_opacity"
+									@input="wm_opacity = parseInt($event.target.value)" />
+								<span class="wm-slider-value">{{ wm_opacity }}%</span>
+							</div>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Size") }}</label>
+								<input type="range" class="wm-slider" min="5" max="100"
+									:value="wm_size"
+									@input="wm_size = parseFloat($event.target.value)" />
+								<span class="wm-slider-value">{{ Math.round(wm_size) }}%</span>
+							</div>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Position X") }}</label>
+								<input type="range" class="wm-slider" min="0" max="100"
+									:value="wm_pos_x"
+									@input="wm_pos_x = parseFloat($event.target.value)" />
+								<span class="wm-slider-value">{{ Math.round(wm_pos_x) }}%</span>
+							</div>
+							<div class="wm-slider-row">
+								<label class="wm-slider-label">{{ __("Position Y") }}</label>
+								<input type="range" class="wm-slider" min="0" max="100"
+									:value="wm_pos_y"
+									@input="wm_pos_y = parseFloat($event.target.value)" />
+								<span class="wm-slider-value">{{ Math.round(wm_pos_y) }}%</span>
+							</div>
+						</template>
+
+						<div class="wm-panel-actions">
+							<button class="btn btn-xs btn-default" @click="wm_reset_defaults">{{ __("Reset") }}</button>
+							<button class="btn btn-xs btn-primary-light" @click="wm_save_defaults">{{ __("Save as Default") }}</button>
+						</div>
+					</div>
+				</div>
+
+				<!-- COMMENTS TAB -->
+				<div v-show="active_tab === 'comments'" class="cropper-tab-pane">
+					<div class="cropper-tab-enable">
+						<span class="cropper-tab-enable-label">{{ __("Enable Comments") }}</span>
+						<div
+							class="toggle-pill toggle-pill-compact"
+							:class="{ active: comments_enabled }"
+							@click="comments_enabled = !comments_enabled"
+						>
+							<span class="toggle-pill-switch">
+								<span class="toggle-pill-track" :class="{ on: comments_enabled }">
+									<span class="toggle-pill-thumb"></span>
+								</span>
+							</span>
+						</div>
+					</div>
+					<div v-if="comments_enabled" class="adjustments-row adjustments-row-comments">
+						<div class="comments-header">
+							<span>{{ __("Comments ({0})", [comment_boxes.length]) }}</span>
+							<div class="comments-actions">
+								<button type="button" class="btn btn-xs btn-primary-light" @click="_add_comment()">
+									+ {{ __("Add") }}
+								</button>
+								<button
+									v-if="comment_presets && comment_presets.length"
+									type="button"
+									class="btn btn-xs btn-default"
+									@click="_toggle_preset_menu()"
+								>
+									📋 {{ __("Presets") }}
+								</button>
+								<div v-if="preset_menu_open" class="comment-preset-menu">
+									<div
+										v-for="(p, pi) in comment_presets"
+										:key="'preset-' + pi"
+										class="comment-preset-item"
+										@click="_insert_preset(p)"
+									>
+										{{ p.text || __("(no text)") }}
+									</div>
+								</div>
+							</div>
+						</div>
+
+						<div v-if="comment_boxes.length === 0" class="comments-empty-hint">
+							{{ __('No comments yet. Click "+ Add" or pick a preset.') }}
+						</div>
+
+						<div
+							v-for="(box, i) in comment_boxes"
+							:key="'box-' + i"
+							class="comment-entry"
+							:class="{ 'comment-entry-selected': selected_comment_idx === i }"
+							@click="selected_comment_idx = i"
+						>
+							<div class="comment-entry-header">
+								<span class="comment-entry-idx">#{{ i + 1 }}</span>
+								<textarea
+									class="comment-text-input"
+									:value="box.text"
+									:placeholder="__('Text…')"
+									rows="1"
+									@input="_update_comment(i, 'text', $event.target.value)"
+								></textarea>
+								<button
+									type="button"
+									class="btn btn-xs btn-danger comment-delete"
+									:title="__('Delete comment')"
+									@click.stop="_delete_comment(i)"
+								>×</button>
+							</div>
+
+							<div class="comment-entry-controls">
+								<label class="comment-control comment-control-wide">
+									<span>{{ __("Font") }}</span>
+									<select class="wm-input comment-font-select"
+										:value="box.font_family"
+										@change="_update_comment(i, 'font_family', $event.target.value)"
+									>
+										<option v-for="f in comment_font_families" :key="f" :value="f">{{ f }}</option>
+									</select>
+								</label>
+								<label class="comment-control">
+									<span>{{ __("Size %") }}</span>
+									<input type="number" class="wm-input comment-num-input"
+										min="1" max="50" step="0.5"
+										:value="box.font_size_pct"
+										@input="_update_comment(i, 'font_size_pct', parseFloat($event.target.value) || 5.0)"
+									/>
+								</label>
+								<button
+									type="button"
+									class="comment-style-btn"
+									:class="{ active: box.font_weight === 'Bold' }"
+									:title="__('Bold')"
+									@click="_update_comment(i, 'font_weight', box.font_weight === 'Bold' ? 'Normal' : 'Bold')"
+								><strong>B</strong></button>
+								<button
+									type="button"
+									class="comment-style-btn"
+									:class="{ active: box.font_style === 'Italic' }"
+									:title="__('Italic')"
+									@click="_update_comment(i, 'font_style', box.font_style === 'Italic' ? 'Normal' : 'Italic')"
+								><em>I</em></button>
+								<input type="color" class="comment-color-input"
+									:title="__('Text color')"
+									:value="box.color"
+									@input="_update_comment(i, 'color', $event.target.value)"
+								/>
+							</div>
+
+							<div class="comment-entry-controls">
+								<div class="comment-align-group">
+									<button
+										v-for="a in ['Left', 'Center', 'Right']"
+										:key="'align-' + a"
+										type="button"
+										class="comment-align-btn"
+										:class="{ active: box.align === a }"
+										:title="__(a)"
+										@click="_update_comment(i, 'align', a)"
+									>{{ a.charAt(0) }}</button>
+								</div>
+								<label class="comment-control">
+									<span>X%</span>
+									<input type="number" class="wm-input comment-num-input"
+										min="0" max="100" step="1"
+										:value="Math.round(box.position_x_pct)"
+										@input="_update_comment(i, 'position_x_pct', parseFloat($event.target.value) || 0)"
+									/>
+								</label>
+								<label class="comment-control">
+									<span>Y%</span>
+									<input type="number" class="wm-input comment-num-input"
+										min="0" max="100" step="1"
+										:value="Math.round(box.position_y_pct)"
+										@input="_update_comment(i, 'position_y_pct', parseFloat($event.target.value) || 0)"
+									/>
+								</label>
+								<label class="comment-control">
+									<span>W%</span>
+									<input type="number" class="wm-input comment-num-input"
+										min="5" max="100" step="1"
+										:value="Math.round(box.width_pct)"
+										@input="_update_comment(i, 'width_pct', parseFloat($event.target.value) || 5)"
+									/>
+								</label>
+							</div>
+						</div>
+
+						<div class="wm-panel-actions">
+							<button class="btn btn-xs btn-default" @click="_reset_comments_to_defaults">
+								{{ __("Reset") }}
+							</button>
+							<button class="btn btn-xs btn-primary-light" @click="_save_comment_defaults">
+								{{ __("Save Style as Default") }}
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<!-- CANVAS TAB (was Resize / Output Shape) -->
+				<div v-show="active_tab === 'canvas'" class="cropper-tab-pane">
+					<div class="cropper-tab-enable">
+						<span class="cropper-tab-enable-label">{{ __("Enable Canvas normalization") }}</span>
+						<div
+							class="toggle-pill toggle-pill-compact"
+							:class="{ active: resize_enabled }"
+							@click="resize_enabled = !resize_enabled"
+						>
+							<span class="toggle-pill-switch">
+								<span class="toggle-pill-track" :class="{ on: resize_enabled }">
+									<span class="toggle-pill-thumb"></span>
+								</span>
+							</span>
+						</div>
+					</div>
+					<div v-if="resize_enabled" class="adjustments-row adjustments-row-resize">
+						<div class="canvas-field">
+							<span class="canvas-sublabel">{{ __("Aspect") }}</span>
+							<div class="segmented-tabs canvas-segmented">
+								<button
+									v-for="a in aspect_ratio_options"
+									:key="a"
+									class="segmented-tab"
+									:class="{ active: resize_aspect === a }"
+									@click="resize_aspect = a"
+								>{{ a }}</button>
+							</div>
+						</div>
+						<div class="canvas-field">
+							<span class="canvas-sublabel">{{ __("Fit mode") }}</span>
+							<div class="segmented-tabs canvas-segmented">
+								<button
+									v-for="m in resize_mode_options"
+									:key="m"
+									class="segmented-tab"
+									:class="{ active: resize_mode === m, disabled: resize_aspect === 'Free' }"
+									:disabled="resize_aspect === 'Free'"
+									@click="resize_mode = m"
+								>{{ __(m) }}</button>
+							</div>
+						</div>
+						<div class="canvas-misc-row">
+							<label class="resize-inline-toggle">
+								<input type="checkbox" v-model="resize_flatten_rgb" />
+								<span>{{ __("Solid background") }}</span>
+							</label>
+							<label
+								v-if="resize_flatten_rgb"
+								class="resize-inline-field"
+							>
+								<span>{{ __("Color") }}</span>
+								<input
+									type="color"
+									class="resize-color"
+									v-model="resize_fill_color"
+								/>
+							</label>
+							<span
+								v-if="!resize_flatten_rgb"
+								class="resize-hint"
+							>
+								{{ __("Transparent background (PNG)") }}
+							</span>
+						</div>
+						<div class="wm-panel-actions">
+							<button class="btn btn-xs btn-default" @click="_reset_canvas_defaults">{{ __("Reset") }}</button>
+							<button class="btn btn-xs btn-primary-light" @click="_save_canvas_defaults">{{ __("Save as Default") }}</button>
+						</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -681,6 +703,10 @@ export default {
 				"Arial", "Helvetica", "Times New Roman",
 				"Courier New", "Georgia", "Verdana",
 			],
+			// Active tab in the right-side panel — "remove_bg" / "watermark"
+			// / "comments" / "canvas". Reset in mounted() to the first
+			// available feature so the right column opens on something.
+			active_tab: "remove_bg",
 		};
 	},
 	watch: {
@@ -717,6 +743,13 @@ export default {
 		},
 	},
 	mounted() {
+		// Initial active tab — open on the first feature that's shown.
+		// Priority: Remove BG → Watermark → Comments → Canvas.
+		if (this.show_remove_bg) this.active_tab = "remove_bg";
+		else if (this.show_watermark) this.active_tab = "watermark";
+		else if (this.show_comments) this.active_tab = "comments";
+		else if (this.show_resize) this.active_tab = "canvas";
+
 		// Remove BG: cached files + bbox metadata (Phase 1)
 		this.original_file = this.file._original_file || this.file.cropper_file;
 		this.nobg_file = this.file._nobg_file || null;
@@ -878,6 +911,49 @@ export default {
 				// so watermark + crop drag still work from the same pixels.
 				pointerEvents: this.interaction_mode === "comment" ? "auto" : "none",
 			};
+		},
+
+		// At least one feature has been turned ON by the user or the
+		// prop defaults. Used to decide whether to render the preview
+		// strip (nothing to preview if everything is off).
+		any_feature_on() {
+			return (
+				(this.show_remove_bg && this.bg_removed) ||
+				(this.show_watermark && this.wm_enabled) ||
+				(this.show_comments && this.comments_enabled) ||
+				(this.show_resize && this.resize_enabled)
+			);
+		},
+
+		// At least one feature's UI is available on this cropper invocation
+		// (prop opted in). Controls whether the right-side tabbed panel
+		// renders at all — if the user opened the cropper with none of the
+		// features enabled, the panel is hidden and the cropper is full-width.
+		any_feature_shown() {
+			return !!(this.show_remove_bg || this.show_watermark ||
+			          this.show_comments || this.show_resize);
+		},
+
+		// Whether to show the 'Drag:' tab row above the cropper. Only
+		// useful when there's a second drag target besides the crop box.
+		show_drag_mode_tabs() {
+			return !!(
+				(this.show_watermark && this.wm_enabled && this.wm_loaded && this.wm_mode === "Corner") ||
+				(this.show_comments && this.comments_enabled && this.comment_boxes.length > 0)
+			);
+		},
+
+		// Human-readable output format label for the preview chip.
+		// Determined by what's on: flatten forces JPEG, otherwise PNG.
+		preview_format_label() {
+			if (this.show_resize && this.resize_enabled && this.resize_flatten_rgb) {
+				return "JPEG";
+			}
+			if (this.bg_removed || this.wm_enabled ||
+			    (this.show_comments && this.comments_enabled && this.comment_boxes.length)) {
+				return "PNG";
+			}
+			return "";
 		},
 	},
 	methods: {
@@ -1355,6 +1431,35 @@ export default {
 				},
 				callback: () => {
 					frappe.show_alert({ message: __("Comment style saved as default"), indicator: "green" });
+				},
+			});
+		},
+
+		// ── Canvas (resize + fill + flatten) reset / save ──
+		_reset_canvas_defaults() {
+			const s = this.resize_settings || {};
+			this.resize_enabled = s.resize_enabled !== undefined ? !!s.resize_enabled : true;
+			this.resize_aspect = s.resize_aspect || "1:1";
+			this.resize_mode = s.resize_mode || "Contain";
+			this.resize_fill_color = s.resize_fill_color || "#FFFFFF";
+			this.resize_flatten_rgb = s.resize_flatten_rgb !== undefined ? !!s.resize_flatten_rgb : true;
+		},
+		_save_canvas_defaults() {
+			frappe.call({
+				method: "frappe.client.set_value",
+				args: {
+					doctype: "Image Processing Settings",
+					name: "Image Processing Settings",
+					fieldname: {
+						resize_enabled: this.resize_enabled ? 1 : 0,
+						resize_aspect: this.resize_aspect,
+						resize_mode: this.resize_mode,
+						resize_fill_color: this.resize_fill_color,
+						resize_flatten_rgb: this.resize_flatten_rgb ? 1 : 0,
+					},
+				},
+				callback: () => {
+					frappe.show_alert({ message: __("Canvas settings saved as default"), indicator: "green" });
 				},
 			});
 		},
@@ -1979,15 +2084,289 @@ export default {
 </script>
 
 <style scoped>
+/* ── Two-column grid layout (new 2026-04) ──
+   Desktop: cropper on the left, tabbed param panel on the right.
+   Mobile: stacked (media query below flips to single-column). */
+.cropper-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(320px, 400px);
+	gap: 16px;
+	align-items: stretch;
+	min-height: 0;
+}
+.cropper-left-col {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	min-height: 0;
+}
+.cropper-right-col {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	min-width: 0;
+	min-height: 0;
+}
+
+/* ── Top toolbar (drag mode + crop ratio, above the cropper) ── */
+.cropper-top-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	padding: 8px 12px;
+	margin-bottom: 8px;
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	background: var(--fg-color, white);
+	align-items: center;
+}
+.cropper-toolbar-group {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+.cropper-toolbar-label {
+	font-size: 12px;
+	color: #606266;
+	font-weight: 500;
+}
+
 img {
 	display: block;
 	max-width: 100%;
-	/* Cap the image so the whole cropper dialog (image + param cards + action
-	   bar + modal chrome) fits inside the viewport. The 420px budget leaves
-	   room for: modal header/footer (~120px), section cards (~220px when both
-	   open), action bar (~50px), and small margins. Fallback 600px keeps
-	   legacy behavior on very tall viewports where calc() overshoots. */
-	max-height: min(600px, calc(100vh - 420px));
+	/* No longer need the 420px budget — the grid flex lets the cropper
+	   grow to fill available vertical space. Just cap for legacy
+	   single-column case. */
+	max-height: min(600px, calc(100vh - 320px));
+}
+
+/* ── Preview bar below cropper ── */
+.cropper-preview-bar {
+	display: flex;
+	gap: 16px;
+	padding: 10px 14px;
+	margin-top: 10px;
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	background: var(--fg-color, white);
+	align-items: center;
+}
+.cropper-preview-thumb {
+	flex-shrink: 0;
+}
+.cropper-preview-thumb canvas {
+	width: 72px;
+	height: 72px;
+	border: 1px solid var(--border-color);
+	background: #ffffff;
+	background-image:
+		linear-gradient(45deg, #f0f0f0 25%, transparent 25%),
+		linear-gradient(-45deg, #f0f0f0 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #f0f0f0 75%),
+		linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
+	background-size: 12px 12px;
+	background-position: 0 0, 0 6px, 6px -6px, -6px 0;
+	border-radius: 4px;
+	display: block;
+}
+.cropper-preview-dims {
+	margin-top: 4px;
+	font-size: 10px;
+	color: #64748b;
+	text-align: center;
+	font-variant-numeric: tabular-nums;
+}
+.cropper-preview-body {
+	flex: 1;
+	min-width: 0;
+}
+.cropper-preview-title {
+	font-weight: 600;
+	font-size: 13px;
+	color: #303133;
+}
+.cropper-preview-hint {
+	margin-left: 6px;
+	font-weight: 400;
+	font-size: 11px;
+	color: #94a3b8;
+}
+.cropper-preview-chips {
+	margin-top: 6px;
+	display: flex;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+.cropper-preview-chip {
+	font-size: 11px;
+	padding: 2px 10px;
+	border-radius: 11px;
+	background: #ecf5ff;
+	color: #3b82f6;
+	border: 1px solid #3b82f6;
+	font-weight: 600;
+}
+
+/* ── Right-side feature tabs ── */
+.cropper-feature-tabs {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+	gap: 6px;
+}
+.cropper-feature-tab {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	padding: 8px 6px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: var(--fg-color, white);
+	cursor: pointer;
+	font-size: 11px;
+	line-height: 1.2;
+	min-height: 50px;
+}
+.cropper-feature-tab:hover {
+	background: #f5faff;
+}
+.cropper-feature-tab.active {
+	border: 2px solid #3b82f6;
+	background: #ecf5ff;
+}
+.cropper-feature-tab-label {
+	font-weight: 600;
+	color: #303133;
+}
+.cropper-feature-tab.active .cropper-feature-tab-label {
+	color: #3b82f6;
+}
+.cropper-feature-tab-state {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 10px;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+.cropper-feature-tab-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: #cbd5e1;
+}
+.cropper-feature-tab-state.on {
+	color: #22c55e;
+}
+.cropper-feature-tab-state.on .cropper-feature-tab-dot {
+	background: #22c55e;
+}
+.cropper-feature-tab-state.off {
+	color: #94a3b8;
+}
+
+/* ── Right-side tab body ── */
+.cropper-tab-body {
+	flex: 1;
+	padding: 12px;
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	background: var(--fg-color, white);
+	overflow-y: auto;
+	min-height: 0;
+}
+.cropper-tab-pane {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+.cropper-tab-enable {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 10px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: #fafbfc;
+}
+.cropper-tab-enable-label {
+	font-size: 13px;
+	font-weight: 600;
+	color: #303133;
+}
+.toggle-pill-compact {
+	padding: 0;
+	border: none;
+	background: none;
+}
+
+/* Canvas tab specific */
+.canvas-field {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+.canvas-sublabel {
+	font-size: 11px;
+	color: #606266;
+	font-weight: 500;
+}
+.canvas-segmented {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+}
+.canvas-segmented .segmented-tab {
+	flex: 1 0 auto;
+	min-width: 48px;
+}
+.canvas-misc-row {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+/* Comments list header */
+.comments-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-weight: 600;
+	font-size: 13px;
+}
+
+/* Watermark slider row */
+.wm-slider-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+.wm-slider-row .wm-slider-label {
+	width: 80px;
+	font-size: 11px;
+	color: #606266;
+}
+.wm-slider-row .wm-slider {
+	flex: 1;
+}
+.wm-slider-row .wm-slider-value {
+	width: 40px;
+	font-size: 11px;
+	color: #303133;
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
+/* ── Mobile: stack left + right columns ── */
+@media (max-width: 900px) {
+	.cropper-grid {
+		grid-template-columns: 1fr;
+	}
+	.cropper-feature-tabs {
+		grid-template-columns: repeat(4, 1fr);
+	}
 }
 
 /* ── Unified Image Adjustments panel ──

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -26,6 +26,27 @@
 					</div>
 				</div>
 
+				<!-- Solid background toggle + colour picker. Live-previewed
+				     in the workspace: when on, the checkerboard behind the
+				     image is replaced with the chosen colour so the user
+				     sees exactly what the flattened JPEG output will look
+				     like. Hidden when fixed_aspect_ratio is set (batch
+				     re-uploads), same as the Crop ratio group — those
+				     flows keep Settings defaults. -->
+				<div class="cropper-toolbar-group cropper-toolbar-bg" v-if="fixed_aspect_ratio == null">
+					<label class="cropper-toolbar-toggle" :title="__('Flatten transparency onto a solid background colour — output becomes JPEG')">
+						<input type="checkbox" v-model="solid_background" />
+						<span>{{ __("Solid bg") }}</span>
+					</label>
+					<input
+						v-if="solid_background"
+						type="color"
+						class="cropper-toolbar-colour"
+						v-model="background_color"
+						:title="__('Background colour')"
+					/>
+				</div>
+
 				<!-- Zoom group — viewMode:0 lets the crop box extend past the
 				     image, so users need explicit zoom controls to zoom out
 				     and see the working area around the picture. Wheel +
@@ -39,6 +60,19 @@
 						<button type="button" class="btn btn-default btn-sm" :title="__('Zoom in')" @click="zoom_by(0.1)">+</button>
 					</div>
 				</div>
+
+				<!-- One Save-as-Default button persists the whole crop
+				     toolbar state (aspect + solid background + colour)
+				     onto Image Processing Settings. Hidden in fixed-ratio
+				     batch flows since those rows don't edit defaults. -->
+				<button
+					v-if="fixed_aspect_ratio == null"
+					class="btn btn-xs btn-primary-light cropper-toolbar-save"
+					:title="__('Remember crop ratio, solid background, and colour as defaults for future uploads')"
+					@click="save_crop_defaults"
+				>
+					{{ __("Save as Default") }}
+				</button>
 
 				<!-- Preview block inline in the toolbar, right-aligned via
 				     margin-left: auto so the full toolbar height stays
@@ -87,7 +121,9 @@
 					ref="wrapper"
 					:class="{
 						'bg-processing': bg_processing,
+						'show-bg-colour': solid_background,
 					}"
+					:style="solid_background ? { '--cropper-bg-colour': background_color } : null"
 					@mousedown="on_wrapper_mousedown"
 					@wheel.prevent="on_wrapper_wheel"
 					@touchstart="on_wrapper_touchstart"
@@ -187,19 +223,6 @@
 					<span class="cropper-feature-tab-state" :class="comments_enabled ? 'on' : 'off'">
 						<span class="cropper-feature-tab-dot"></span>
 						{{ comments_enabled ? __("on") : __("off") }}
-					</span>
-				</button>
-				<button
-					v-if="show_resize"
-					type="button"
-					class="cropper-feature-tab"
-					:class="{ active: active_tab === 'canvas' }"
-					@click="active_tab = 'canvas'"
-				>
-					<span class="cropper-feature-tab-label">{{ __("Canvas") }}</span>
-					<span class="cropper-feature-tab-state" :class="resize_enabled ? 'on' : 'off'">
-						<span class="cropper-feature-tab-dot"></span>
-						{{ resize_enabled ? __("on") : __("off") }}
 					</span>
 				</button>
 			</div>
@@ -570,78 +593,6 @@
 						</div>
 					</div>
 				</div>
-
-				<!-- CANVAS TAB (was Resize / Output Shape) -->
-				<div v-show="active_tab === 'canvas'" class="cropper-tab-pane">
-					<div class="cropper-tab-enable">
-						<span class="cropper-tab-enable-label">{{ __("Enable Canvas normalization") }}</span>
-						<div
-							class="toggle-pill toggle-pill-compact"
-							:class="{ active: resize_enabled }"
-							@click="resize_enabled = !resize_enabled"
-						>
-							<span class="toggle-pill-switch">
-								<span class="toggle-pill-track" :class="{ on: resize_enabled }">
-									<span class="toggle-pill-thumb"></span>
-								</span>
-							</span>
-						</div>
-					</div>
-					<div v-if="resize_enabled" class="adjustments-row adjustments-row-resize">
-						<div class="canvas-field">
-							<span class="canvas-sublabel">{{ __("Aspect") }}</span>
-							<div class="segmented-tabs canvas-segmented">
-								<button
-									v-for="a in aspect_ratio_options"
-									:key="a"
-									class="segmented-tab"
-									:class="{ active: resize_aspect === a }"
-									@click="resize_aspect = a"
-								>{{ a }}</button>
-							</div>
-						</div>
-						<div class="canvas-field">
-							<span class="canvas-sublabel">{{ __("Fit mode") }}</span>
-							<div class="segmented-tabs canvas-segmented">
-								<button
-									v-for="m in resize_mode_options"
-									:key="m"
-									class="segmented-tab"
-									:class="{ active: resize_mode === m, disabled: resize_aspect === 'Free' }"
-									:disabled="resize_aspect === 'Free'"
-									@click="resize_mode = m"
-								>{{ __(m) }}</button>
-							</div>
-						</div>
-						<div class="canvas-misc-row">
-							<label class="resize-inline-toggle">
-								<input type="checkbox" v-model="resize_flatten_rgb" />
-								<span>{{ __("Solid background") }}</span>
-							</label>
-							<label
-								v-if="resize_flatten_rgb"
-								class="resize-inline-field"
-							>
-								<span>{{ __("Color") }}</span>
-								<input
-									type="color"
-									class="resize-color"
-									v-model="resize_fill_color"
-								/>
-							</label>
-							<span
-								v-if="!resize_flatten_rgb"
-								class="resize-hint"
-							>
-								{{ __("Transparent background (PNG)") }}
-							</span>
-						</div>
-						<div class="wm-panel-actions">
-							<button class="btn btn-xs btn-default" @click="_reset_canvas_defaults">{{ __("Reset") }}</button>
-							<button class="btn btn-xs btn-primary-light" @click="_save_canvas_defaults">{{ __("Save as Default") }}</button>
-						</div>
-					</div>
-				</div>
 			</div>
 		</div>
 		<!-- Bottom action row spans both columns so Back / Crop sit in the
@@ -673,9 +624,16 @@ export default {
 	props: [
 		"file", "fixed_aspect_ratio",
 		"show_remove_bg", "remove_bg_checked", "remove_bg_padding_pct",
+		// Initial crop-box aspect remembered in Image Processing Settings
+		// ("Free" | "1:1" | "4:3" | "16:9"). Seeds the toolbar button row.
+		"default_crop_aspect",
+		// Solid Background toggle + colour remembered in Settings. When
+		// on, the workspace paints the colour behind the image and the
+		// final crop is flattened to that colour (JPEG). When off, the
+		// workspace shows CropperJS's checkerboard and the output keeps
+		// its alpha channel as PNG.
+		"default_solid_background", "default_background_color",
 		"show_watermark", "watermark_settings", "wm_default_enabled",
-		// Resize (new 2026-04) — from Image Processing Settings via item.js
-		"show_resize", "resize_settings", "resize_default_enabled",
 		// Comments (new 2026-04) — simple list of text overlays baked into
 		// the final output. The single-item flow uses a lightweight
 		// textarea-based editor (no drag). Batch flow uses the full
@@ -691,7 +649,14 @@ export default {
 			src: null,
 			cropper: null,
 			image: null,
+			// Seeded from default_crop_aspect prop in mounted(). NaN = Free
+			// (user picks a ratio in the toolbar). Numeric otherwise.
 			aspect_ratio: NaN,
+			// Solid Background state — seeded in mounted() from the
+			// matching default_* props. Watcher below keeps the workspace
+			// backdrop style + preview re-render in sync with edits.
+			solid_background: false,
+			background_color: "#FFFFFF",
 			// Remove BG
 			bg_removed: false,
 			bg_processing: false,
@@ -732,19 +697,6 @@ export default {
 			// gate drag permissions — every overlay element captures its
 			// own events regardless of selected_type.
 			selected_type: "crop",
-			// Output Shape (new 2026-04) — baked into the final cropped canvas
-			// before upload. Same logic as the server-side PIL helper in
-			// item_image_batch.py::_apply_aspect_normalize.
-			resize_enabled: false,
-			resize_aspect: "1:1",
-			resize_mode: "Contain",
-			resize_fill_color: "#FFFFFF",
-			resize_flatten_rgb: true,
-			// max_file_size_kb intentionally NOT tracked in local state —
-			// it's a global Settings value enforced server-side when a
-			// batch is processed. Single-item uploads don't need it.
-			aspect_ratio_options: ["1:1", "4:3", "16:9", "3:2", "2:3", "Free"],
-			resize_mode_options: ["Contain", "Cover", "Stretch"],
 			// Live preview (new 2026-04) — rerenders on any resize param
 			// change so the user sees exactly what Crop will produce.
 			preview_dims: null,
@@ -786,7 +738,23 @@ export default {
 	},
 	watch: {
 		aspect_ratio(value) {
-			if (this.cropper) {
+			if (!this.cropper) return;
+			// When we have a Remove BG bbox, re-snap the crop box to that
+			// bbox + padding expanded to the new aspect (and auto-zoom).
+			// This gives the user "change aspect, product recentres" —
+			// better than CropperJS's default which anchors on the
+			// existing rect's top-left corner.
+			if (this.bg_removed && this.nobg_bbox) {
+				this._apply_auto_crop();
+				return;
+			}
+			// Otherwise: reshape the current crop rect around its centre.
+			const cur = this.cropper.getData();
+			if (cur && Number.isFinite(value) && value > 0) {
+				const new_rect = this._expand_rect_to_aspect(cur, value);
+				this.cropper.setAspectRatio(value);
+				this.cropper.setData(new_rect);
+			} else {
 				this.cropper.setAspectRatio(value);
 			}
 		},
@@ -800,24 +768,11 @@ export default {
 		active_tab() {
 			this._schedule_preview_update();
 		},
-		// Any change to resize params → rerender the preview. Debounced
-		// so slider drags don't hammer the off-screen canvas composite.
-		resize_enabled(v) {
-			this._schedule_preview_update();
-			this.$emit("resize_enabled_changed", !!v);
-		},
-		// Merged with the duplicate comments_enabled() below to preserve
-		// the $emit (Vue keeps only the last-declared watcher of the same
-		// key). Without this, FileUploader.comments_enabled_default never
-		// re-syncs with the cropper's toggle.
-
-		resize_aspect() { this._schedule_preview_update(); },
-		resize_mode() { this._schedule_preview_update(); },
-		resize_fill_color() { this._schedule_preview_update(); },
-		resize_flatten_rgb() { this._schedule_preview_update(); },
 		// Watermark + padding also affect final output — refresh preview
 		// on those too so the user sees the composite result.
 		wm_enabled() { this._schedule_preview_update(); },
+		solid_background() { this._schedule_preview_update(); },
+		background_color() { this._schedule_preview_update(); },
 		wm_opacity() { this._schedule_preview_update(); },
 		wm_size() { this._schedule_preview_update(); },
 		wm_pos_x() { this._schedule_preview_update(); },
@@ -862,12 +817,23 @@ export default {
 		},
 	},
 	mounted() {
+		// Seed the crop-box aspect from the user's remembered default.
+		// fixed_aspect_ratio (set by the batch per-row cropper via
+		// restrictions.crop_image_aspect_ratio) takes precedence —
+		// batch rows enforce 1:1 and the toolbar is hidden there.
+		if (this.fixed_aspect_ratio != null) {
+			this.aspect_ratio = Number(this.fixed_aspect_ratio);
+		} else if (this.default_crop_aspect) {
+			this.aspect_ratio = this._aspect_string_to_number(this.default_crop_aspect);
+		}
+		this.solid_background = !!this.default_solid_background;
+		this.background_color = this.default_background_color || "#FFFFFF";
+
 		// Initial active tab — open on the first feature that's shown.
-		// Priority: Remove BG → Watermark → Comments → Canvas.
+		// Priority: Remove BG → Watermark → Comments.
 		if (this.show_remove_bg) this.active_tab = "remove_bg";
 		else if (this.show_watermark) this.active_tab = "watermark";
 		else if (this.show_comments) this.active_tab = "comments";
-		else if (this.show_resize) this.active_tab = "canvas";
 
 		// Remove BG: cached files + bbox metadata (Phase 1)
 		this.original_file = this.file._original_file || this.file.cropper_file;
@@ -904,25 +870,6 @@ export default {
 			this.wm_tile_rotation = this.watermark_settings.tile_rotation != null ? this.watermark_settings.tile_rotation : -30;
 			this.wm_tile_spacing = this.watermark_settings.tile_spacing || 40;
 			this.load_watermark_image(this.watermark_settings.watermark_image);
-		}
-
-		// Resize: load settings (new 2026-04). The pre-cropper footer
-		// toggle (resize_default_enabled) wins over Settings so a user
-		// who flipped Canvas off on the file-picker page stays off.
-		if (this.show_resize && this.resize_settings) {
-			this.resize_enabled = this.resize_default_enabled != null
-				? !!this.resize_default_enabled
-				: !!this.resize_settings.resize_enabled;
-			this.resize_aspect = this.resize_settings.resize_aspect || "1:1";
-			this.resize_mode = this.resize_settings.resize_mode || "Contain";
-			this.resize_fill_color = this.resize_settings.resize_fill_color || "#FFFFFF";
-			// Default to true when the settings object has no explicit
-			// value (undefined) — the doctype default is 1, so a newly
-			// installed site shouldn't accidentally produce transparent
-			// PNGs just because the settings object was cached before
-			// this field existed.
-			this.resize_flatten_rgb = this.resize_settings.resize_flatten_rgb !== false;
-			// (max_file_size_kb is global Settings only; not read here)
 		}
 
 		// Comments: off by default on new uploads unless the footer
@@ -1120,8 +1067,7 @@ export default {
 			return (
 				(this.show_remove_bg && this.bg_removed) ||
 				(this.show_watermark && this.wm_enabled) ||
-				(this.show_comments && this.comments_enabled) ||
-				(this.show_resize && this.resize_enabled)
+				(this.show_comments && this.comments_enabled)
 			);
 		},
 
@@ -1130,16 +1076,13 @@ export default {
 		// renders at all — if the user opened the cropper with none of the
 		// features enabled, the panel is hidden and the cropper is full-width.
 		any_feature_shown() {
-			return !!(this.show_remove_bg || this.show_watermark ||
-			          this.show_comments || this.show_resize);
+			return !!(this.show_remove_bg || this.show_watermark || this.show_comments);
 		},
 
 		// Human-readable output format label for the preview chip.
-		// Determined by what's on: flatten forces JPEG, otherwise PNG.
+		// PNG when we have alpha-bearing output (Remove BG / Watermark /
+		// Comments baked in); blank otherwise (no processing = original file).
 		preview_format_label() {
-			if (this.show_resize && this.resize_enabled && this.resize_flatten_rgb) {
-				return "JPEG";
-			}
 			if (this.bg_removed || this.wm_enabled ||
 			    (this.show_comments && this.comments_enabled && this.comment_boxes.length)) {
 				return "PNG";
@@ -1239,22 +1182,136 @@ export default {
 		_apply_auto_crop() {
 			// Snap the Cropper crop box to the product's non-transparent bounding
 			// box plus a configurable padding. Called from the Cropper `ready`
-			// callback after a Remove BG result is loaded.
+			// callback after a Remove BG result is loaded, and again whenever
+			// the user changes the aspect button or padding slider.
 			//
-			// Padding is a percentage of the LONGER side of the bbox (so wide or
-			// tall products both get a proportional border). Negative values
-			// tighten into the bbox to shed anti-aliasing halos. CropperJS clamps
-			// the final rectangle to the image bounds automatically.
+			// Padding is a percentage of the LONGER side of the bbox (so wide
+			// or tall products both get a proportional border). Negative values
+			// tighten into the bbox to shed anti-aliasing halos.
+			//
+			// With an aspect constraint active, the bbox+padding rect is
+			// LETTERBOXED (never cropped) to match the target aspect by
+			// expanding the shorter side around the product centre. viewMode:0
+			// on the cropper lets the rect extend past the image bounds — the
+			// workspace shows the overflow area as either checkerboard
+			// (transparent output) or the solid background colour.
 			if (!this.cropper || !this.nobg_bbox) return;
 			const { x, y, width, height } = this.nobg_bbox;
 			const padding_pct = this.effective_padding_pct;
 			const pad = (padding_pct / 100) * Math.max(width, height);
-			this.cropper.setData({
+			let rect = {
 				x: x - pad,
 				y: y - pad,
 				width: width + 2 * pad,
 				height: height + 2 * pad,
-			});
+			};
+			rect = this._expand_rect_to_aspect(rect, this.aspect_ratio);
+			this.cropper.setData(rect);
+			this._zoom_to_fit_rect(rect, 0.12);
+		},
+
+		// Grow the shorter side of `rect` around its centre so it matches
+		// `aspect` (w/h). NaN/invalid aspect returns rect untouched. Never
+		// shrinks — overflow past the image is fine (viewMode:0).
+		_expand_rect_to_aspect(rect, aspect) {
+			if (!Number.isFinite(aspect) || aspect <= 0) return rect;
+			const cur = rect.width / rect.height;
+			if (Math.abs(cur - aspect) < 1e-4) return rect;
+			if (cur < aspect) {
+				const new_w = rect.height * aspect;
+				return {
+					x: rect.x - (new_w - rect.width) / 2,
+					y: rect.y,
+					width: new_w,
+					height: rect.height,
+				};
+			}
+			const new_h = rect.width / aspect;
+			return {
+				x: rect.x,
+				y: rect.y - (new_h - rect.height) / 2,
+				width: rect.width,
+				height: new_h,
+			};
+		},
+
+		// Auto-zoom so `rect` (natural-image coords) fills the workspace
+		// with a ~margin_ratio breathing room. `cropper.zoomTo` mutates
+		// internal view state, so we re-assert the crop box afterwards.
+		_zoom_to_fit_rect(rect, margin_ratio) {
+			if (!this.cropper || !this.$refs.wrapper) return;
+			const container = this.$refs.wrapper.getBoundingClientRect();
+			if (!container.width || !container.height) return;
+			const tw = container.width * (1 - 2 * margin_ratio);
+			const th = container.height * (1 - 2 * margin_ratio);
+			const scale = Math.min(tw / rect.width, th / rect.height);
+			if (!Number.isFinite(scale) || scale <= 0) return;
+			try {
+				this.cropper.zoomTo(scale);
+				this.cropper.setData(rect);
+			} catch (e) {
+				// cropper may still be laying out — ignore
+			}
+		},
+
+		// "1:1" → 1, "4:3" → 4/3, "16:9" → 16/9, "Free"/unknown → NaN.
+		_aspect_string_to_number(s) {
+			if (!s || s === "Free") return NaN;
+			const parts = String(s).split(":");
+			if (parts.length !== 2) return NaN;
+			const w = Number(parts[0]);
+			const h = Number(parts[1]);
+			if (!Number.isFinite(w) || !Number.isFinite(h) || h === 0) return NaN;
+			return w / h;
+		},
+
+		// 1 → "1:1", 4/3 → "4:3", NaN → "Free". Matches the options set
+		// on Image Processing Settings.crop_aspect (Select).
+		_aspect_number_to_string(n) {
+			if (!Number.isFinite(n)) return "Free";
+			if (Math.abs(n - 1) < 1e-4) return "1:1";
+			if (Math.abs(n - 4 / 3) < 1e-4) return "4:3";
+			if (Math.abs(n - 16 / 9) < 1e-4) return "16:9";
+			return "Free";
+		},
+
+		async save_crop_defaults() {
+			// Persist the full Crop-toolbar state (aspect + solid
+			// background + colour) as system-wide defaults in Image
+			// Processing Settings. Updating in-process cache too so
+			// re-opening the uploader without refreshing picks up the
+			// new defaults. Mirrors save_padding_default.
+			const aspect = this._aspect_number_to_string(this.aspect_ratio);
+			const solid = this.solid_background ? 1 : 0;
+			const colour = this.background_color || "#FFFFFF";
+			try {
+				await frappe.call({
+					method: "frappe.client.set_value",
+					args: {
+						doctype: "Image Processing Settings",
+						name: "Image Processing Settings",
+						fieldname: {
+							crop_aspect: aspect,
+							solid_background: solid,
+							background_color: colour,
+						},
+					},
+				});
+				if (frappe._image_processing_settings_cache) {
+					frappe._image_processing_settings_cache.crop_aspect = aspect;
+					frappe._image_processing_settings_cache.solid_background = !!solid;
+					frappe._image_processing_settings_cache.background_color = colour;
+				}
+				frappe.show_alert({
+					message: __("Crop defaults saved"),
+					indicator: "green",
+				});
+			} catch (e) {
+				frappe.show_alert({
+					message: __("Failed to save default"),
+					indicator: "red",
+				});
+			}
 		},
 
 		// ── Remove BG padding control (Phase 1 — live-edit from Remove BG card) ──
@@ -1323,22 +1380,14 @@ export default {
 				this._composite_comments_on_canvas(canvas, cctx);
 			}
 
-			// ── Resize step (new 2026-04) ──
-			// Apply aspect normalization + optional RGB flatten to a fresh
-			// canvas that mirrors the server-side PIL helper in
-			// item_image_batch.py::_apply_aspect_normalize. Happens AFTER the
-			// watermark + comments composites (so both stay on product
-			// content, not on Contain-padded fill strips).
+			// If Solid Background is on, flatten the cropped canvas onto
+			// the chosen colour before encoding. Produces JPEG (opaque,
+			// smaller); otherwise keep alpha as PNG when Remove BG /
+			// Watermark ran, or fall back to the source type.
 			let final_canvas = canvas;
-			if (this.show_resize && this.resize_enabled) {
-				final_canvas = this._apply_output_shape(canvas);
-			}
-
-			// Pick a type: flatten → JPEG (smaller, opaque); otherwise PNG
-			// when Remove BG or Watermark was applied (needs alpha or we
-			// have pixels that don't match the source type).
 			let file_type;
-			if (this.show_resize && this.resize_enabled && this.resize_flatten_rgb) {
+			if (this.solid_background) {
+				final_canvas = this._flatten_onto_colour(canvas, this.background_color || "#FFFFFF");
 				file_type = "image/jpeg";
 			} else if (this.bg_removed || this.wm_enabled) {
 				file_type = "image/png";
@@ -1350,10 +1399,7 @@ export default {
 				let name = this.file.name;
 				if (this.bg_removed) name = name.replace(/\.[^.]+$/, "_nobg.png");
 				if (this.wm_enabled) name = name.replace(/\.[^.]+$/, "_wm.png");
-				if (this.show_resize && this.resize_enabled) {
-					const ext = file_type === "image/jpeg" ? ".jpg" : ".png";
-					name = name.replace(/\.[^.]+$/, "_shape" + ext);
-				}
+				if (this.solid_background) name = name.replace(/\.[^.]+$/, ".jpg");
 				this.file.file_obj = new File([blob], name, { type: blob.type });
 				this.file.name = name;
 				// Emit the final settings snapshot so FileUploader's Step 3
@@ -1366,118 +1412,25 @@ export default {
 					watermark_mode: this.wm_mode,
 					comments_enabled: !!this.comments_enabled,
 					comment_count: (this.comment_boxes || []).length,
-					resize_enabled: !!this.resize_enabled,
-					resize_aspect: this.resize_aspect,
-					resize_mode: this.resize_mode,
+					crop_aspect: this._aspect_number_to_string(this.aspect_ratio),
+					solid_background: !!this.solid_background,
+					background_color: this.background_color,
 				});
 				this.$emit("toggle_image_cropper");
 			}, file_type, file_type === "image/jpeg" ? 0.92 : undefined);
 		},
 
-		// Aspect-normalize a canvas via Canvas 2D. Mirrors the server-side
-		// _apply_aspect_normalize in item_image_batch.py so the baked file
-		// from a single-image upload and from a batch process look the same.
-		_apply_output_shape(src_canvas) {
-			const aspect_map = {
-				"1:1": [1, 1],
-				"4:3": [4, 3],
-				"16:9": [16, 9],
-				"3:2": [3, 2],
-				"2:3": [2, 3],
-			};
-
-			const aspect = this.resize_aspect;
-			const mode = this.resize_mode;
-			const sw = src_canvas.width;
-			const sh = src_canvas.height;
-
-			// Free or unknown → pass-through (optionally flatten)
-			if (aspect === "Free" || !(aspect in aspect_map)) {
-				return this._maybe_flatten(src_canvas, sw, sh, src_canvas);
-			}
-
-			const [tw, th] = aspect_map[aspect];
-			const src_ratio = sw / sh;
-			const tgt_ratio = tw / th;
-
-			if (Math.abs(src_ratio - tgt_ratio) < 1e-3) {
-				return this._maybe_flatten(src_canvas, sw, sh, src_canvas);
-			}
-
-			if (mode === "Stretch") {
-				let new_w, new_h;
-				if (src_ratio > tgt_ratio) {
-					new_w = sw;
-					new_h = Math.round(sw / tgt_ratio);
-				} else {
-					new_w = Math.round(sh * tgt_ratio);
-					new_h = sh;
-				}
-				const out = document.createElement("canvas");
-				out.width = new_w;
-				out.height = new_h;
-				out.getContext("2d").drawImage(src_canvas, 0, 0, new_w, new_h);
-				return this._maybe_flatten(out, new_w, new_h, out);
-			}
-
-			if (mode === "Cover") {
-				let new_w, new_h, off_x = 0, off_y = 0;
-				if (src_ratio > tgt_ratio) {
-					// Source wider — crop left/right
-					new_w = Math.round(sh * tgt_ratio);
-					new_h = sh;
-					off_x = Math.floor((sw - new_w) / 2);
-				} else {
-					// Source taller — crop top/bottom
-					new_w = sw;
-					new_h = Math.round(sw / tgt_ratio);
-					off_y = Math.floor((sh - new_h) / 2);
-				}
-				const out = document.createElement("canvas");
-				out.width = new_w;
-				out.height = new_h;
-				out.getContext("2d").drawImage(
-					src_canvas,
-					off_x, off_y, new_w, new_h,
-					0, 0, new_w, new_h,
-				);
-				return this._maybe_flatten(out, new_w, new_h, out);
-			}
-
-			// Contain: expand shorter axis, pad with fill color.
-			let canvas_w, canvas_h;
-			if (src_ratio > tgt_ratio) {
-				canvas_w = sw;
-				canvas_h = Math.round(sw / tgt_ratio);
-			} else {
-				canvas_w = Math.round(sh * tgt_ratio);
-				canvas_h = sh;
-			}
+		// Paint `src` on top of a solid-colour fill canvas of the same
+		// dimensions so alpha pixels get baked onto `hex`. Used by
+		// crop_image() + _render_preview() when Solid Background is on.
+		_flatten_onto_colour(src, hex) {
 			const out = document.createElement("canvas");
-			out.width = canvas_w;
-			out.height = canvas_h;
+			out.width = src.width;
+			out.height = src.height;
 			const ctx = out.getContext("2d");
-			// Fill the padding area first — transparent if flatten is off,
-			// or fill color if flatten is on so the composite is opaque.
-			if (this.resize_flatten_rgb) {
-				ctx.fillStyle = this.resize_fill_color || "#FFFFFF";
-				ctx.fillRect(0, 0, canvas_w, canvas_h);
-			}
-			const paste_x = Math.floor((canvas_w - sw) / 2);
-			const paste_y = Math.floor((canvas_h - sh) / 2);
-			ctx.drawImage(src_canvas, paste_x, paste_y);
-			return this._maybe_flatten(out, canvas_w, canvas_h, out);
-		},
-
-		_maybe_flatten(maybe_rgba_canvas, w, h, src_canvas) {
-			if (!this.resize_flatten_rgb) return maybe_rgba_canvas;
-			const out = document.createElement("canvas");
-			out.width = w;
-			out.height = h;
-			const ctx = out.getContext("2d");
-			ctx.fillStyle = this.resize_fill_color || "#FFFFFF";
-			ctx.fillRect(0, 0, w, h);
-			ctx.drawImage(src_canvas, 0, 0);
+			ctx.fillStyle = hex || "#FFFFFF";
+			ctx.fillRect(0, 0, out.width, out.height);
+			ctx.drawImage(src, 0, 0);
 			return out;
 		},
 
@@ -1779,35 +1732,6 @@ export default {
 			});
 		},
 
-		// ── Canvas (resize + fill + flatten) reset / save ──
-		_reset_canvas_defaults() {
-			const s = this.resize_settings || {};
-			this.resize_enabled = s.resize_enabled !== undefined ? !!s.resize_enabled : true;
-			this.resize_aspect = s.resize_aspect || "1:1";
-			this.resize_mode = s.resize_mode || "Contain";
-			this.resize_fill_color = s.resize_fill_color || "#FFFFFF";
-			this.resize_flatten_rgb = s.resize_flatten_rgb !== undefined ? !!s.resize_flatten_rgb : true;
-		},
-		_save_canvas_defaults() {
-			frappe.call({
-				method: "frappe.client.set_value",
-				args: {
-					doctype: "Image Processing Settings",
-					name: "Image Processing Settings",
-					fieldname: {
-						resize_enabled: this.resize_enabled ? 1 : 0,
-						resize_aspect: this.resize_aspect,
-						resize_mode: this.resize_mode,
-						resize_fill_color: this.resize_fill_color,
-						resize_flatten_rgb: this.resize_flatten_rgb ? 1 : 0,
-					},
-				},
-				callback: () => {
-					frappe.show_alert({ message: __("Canvas settings saved as default"), indicator: "green" });
-				},
-			});
-		},
-
 		_add_comment() {
 			const d = this.comment_defaults || {};
 			this.comment_boxes.push({
@@ -1986,8 +1910,7 @@ export default {
 			if (!this.cropper) return;
 
 			// Run the same pipeline crop_image would, but draw to a
-			// 200×200 display canvas. Reuses _apply_output_shape so
-			// preview + actual output match exactly.
+			// 200×200 display canvas so preview + actual output match.
 			let src;
 			try {
 				src = this.cropper.getCroppedCanvas();
@@ -1996,7 +1919,7 @@ export default {
 			}
 			if (!src) return;
 
-			// Apply watermark to a working copy (off-screen)
+			// Apply watermark + comments to a working copy (off-screen).
 			const work = document.createElement("canvas");
 			work.width = src.width;
 			work.height = src.height;
@@ -2005,15 +1928,11 @@ export default {
 			if (this.wm_enabled && this.wm_loaded && this.wm_img) {
 				this._composite_watermark_on_canvas(work, wctx);
 			}
-			// Comments — baked BEFORE Resize so box positions stay attached
-			// to product content, not to Contain-padded fill strips.
 			if (this.show_comments && this.comments_enabled) {
 				this._composite_comments_on_canvas(work, wctx);
 			}
-
-			// Apply Resize (same helper used on final crop)
-			const final_canvas = (this.show_resize && this.resize_enabled)
-				? this._apply_output_shape(work)
+			const final_canvas = this.solid_background
+				? this._flatten_onto_colour(work, this.background_color || "#FFFFFF")
 				: work;
 
 			// Compute display box from the preview thumb's actual rendered
@@ -2695,7 +2614,7 @@ export default {
 .cropper-top-toolbar {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 16px;
+	gap: 12px 16px;
 	padding: 8px 12px;
 	margin-bottom: 8px;
 	border: 1px solid var(--border-color);
@@ -2707,11 +2626,50 @@ export default {
 	display: inline-flex;
 	align-items: center;
 	gap: 8px;
+	flex-shrink: 0;
 }
 .cropper-toolbar-label {
 	font-size: 12px;
 	color: #606266;
 	font-weight: 500;
+}
+.cropper-toolbar-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	margin: 0;
+	font-size: 12px;
+	color: #303133;
+	cursor: pointer;
+	user-select: none;
+}
+.cropper-toolbar-toggle input[type="checkbox"] {
+	margin: 0;
+}
+.cropper-toolbar-colour {
+	width: 26px;
+	height: 26px;
+	padding: 0;
+	border: 1px solid #dcdfe6;
+	border-radius: 4px;
+	background: white;
+	cursor: pointer;
+}
+.cropper-toolbar-save {
+	flex-shrink: 0;
+}
+
+/* Mobile: workspace fills viewport width, toolbar wraps to multiple rows
+   naturally. Shrink the Preview block so it doesn't push other groups
+   off the grid, and let Save sit on its own line alongside Preview. */
+@media (max-width: 768px) {
+	.cropper-top-toolbar {
+		gap: 8px 10px;
+		padding: 8px;
+	}
+	.cropper-toolbar-preview {
+		margin-left: 0;
+	}
 }
 
 img {
@@ -3207,6 +3165,16 @@ img {
 	max-width: 100%;
 	max-height: 100%;
 	display: block;
+}
+
+/* Solid Background live preview: swap CropperJS's built-in checkerboard
+   (its .cropper-bg, which is a repeating bg.png) for the chosen colour
+   so the user sees exactly what the flattened JPEG output will look
+   like. --cropper-bg-colour is set inline by the component's :style
+   binding based on background_color. */
+.cropper-image-wrapper.show-bg-colour >>> .cropper-bg {
+	background-image: none !important;
+	background-color: var(--cropper-bg-colour, #ffffff) !important;
 }
 
 /* While Remove BG is running, hide CropperJS's own crop-box chrome so the

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -115,6 +115,12 @@
 							:title="__('Rotate')"
 							@mousedown.stop="on_comment_rotate_mousedown($event, i)"
 						>↻</div>
+						<div
+							v-if="selected_comment_idx === i && interaction_mode === 'comment'"
+							class="comment-resize-handle"
+							:title="__('Resize')"
+							@mousedown.stop="on_comment_resize_mousedown($event, i)"
+						></div>
 					</div>
 				</div>
 				<div v-if="bg_processing" class="cropper-loading-overlay">
@@ -982,13 +988,11 @@ export default {
 			          this.show_comments || this.show_resize);
 		},
 
-		// Whether to show the 'Drag:' tab row above the cropper. Only
-		// useful when there's a second drag target besides the crop box.
+		// Whether to show the 'Drag:' tab row above the cropper. Always
+		// rendered so toggling watermark / comment on doesn't cause the
+		// layout to shift — the 'Crop box' button is always visible.
 		show_drag_mode_tabs() {
-			return !!(
-				(this.show_watermark && this.wm_enabled && this.wm_loaded && this.wm_mode === "Corner") ||
-				(this.show_comments && this.comments_enabled && this.comment_boxes.length > 0)
-			);
+			return true;
 		},
 
 		// Human-readable output format label for the preview chip.
@@ -1462,6 +1466,23 @@ export default {
 			};
 			e.preventDefault();
 		},
+		on_comment_resize_mousedown(e, i) {
+			if (this.interaction_mode !== "comment") return;
+			const cd = this._canvas_data;
+			if (!cd) return;
+			this.selected_comment_idx = i;
+			this.comment_dragging_idx = i;
+			const box = this.comment_boxes[i];
+			this._comment_drag_start = {
+				mode: "resize",
+				clientX: e.clientX,
+				clientY: e.clientY,
+				origWPct: box.width_pct || 40,
+				origHPct: box.height_pct || 10,
+				origFontPct: box.font_size_pct || 5,
+			};
+			e.preventDefault();
+		},
 		_on_comment_mousemove(e) {
 			if (this.comment_dragging_idx < 0 || !this._comment_drag_start) return;
 			const start = this._comment_drag_start;
@@ -1484,6 +1505,27 @@ export default {
 
 			const cd = this._canvas_data;
 			if (!cd) return;
+
+			if (start.mode === "resize") {
+				const dx = e.clientX - start.clientX;
+				const dy = e.clientY - start.clientY;
+				const dwPct = (dx / cd.width) * 100 * 2;   // ×2 because we resize from center
+				const dhPct = (dy / cd.height) * 100 * 2;
+				const newW = Math.max(5, Math.min(100, start.origWPct + dwPct));
+				const newH = Math.max(2, Math.min(100, start.origHPct + dhPct));
+				// Scale font proportionally with height change (same rule as
+				// CommentBoxEditor's resize handle).
+				const ratio = newH / Math.max(start.origHPct, 0.1);
+				const newFont = Math.max(0.1, Math.min(50, start.origFontPct * ratio));
+				this.$set(this.comment_boxes, i, {
+					...box,
+					width_pct: newW,
+					height_pct: newH,
+					font_size_pct: newFont,
+				});
+				return;
+			}
+
 			const dx = e.clientX - start.clientX;
 			const dy = e.clientY - start.clientY;
 			const dxPct = (dx / cd.width) * 100;
@@ -2493,9 +2535,9 @@ img {
 	gap: 6px;
 }
 .canvas-sublabel {
-	font-size: 11px;
-	color: #606266;
-	font-weight: 500;
+	font-size: 14px;
+	color: #475569;
+	font-weight: 600;
 }
 .canvas-segmented {
 	display: flex;
@@ -2519,7 +2561,7 @@ img {
 	justify-content: space-between;
 	align-items: center;
 	font-weight: 600;
-	font-size: 13px;
+	font-size: 15px;
 }
 
 /* Watermark slider row */
@@ -3006,9 +3048,10 @@ img {
 	flex-wrap: wrap;
 }
 .resize-sublabel {
-	min-width: 52px;
-	font-size: 12px;
-	color: #606266;
+	min-width: 60px;
+	font-size: 14px;
+	font-weight: 600;
+	color: #475569;
 }
 .resize-misc-row {
 	display: flex;
@@ -3021,13 +3064,14 @@ img {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	font-size: 12px;
-	color: #606266;
+	font-size: 15px;
+	color: #475569;
+	font-weight: 500;
 }
 .resize-color {
-	width: 28px;
-	height: 24px;
-	padding: 0;
+	width: 36px;
+	height: 28px;
+	padding: 2px;
 	border: 1px solid #cbd5e1;
 	border-radius: 4px;
 	cursor: pointer;
@@ -3036,10 +3080,17 @@ img {
 .resize-inline-toggle {
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
-	font-size: 12px;
-	color: #606266;
+	gap: 8px;
+	font-size: 15px;
+	color: #475569;
+	font-weight: 500;
 	cursor: pointer;
+}
+.resize-inline-toggle input[type="checkbox"] {
+	width: 18px;
+	height: 18px;
+	cursor: pointer;
+	margin: 0;
 }
 .toggle-pill-sublabel {
 	font-size: 10px;
@@ -3127,42 +3178,66 @@ img {
 	gap: 6px;
 }
 .comment-entry-idx {
-	font-size: 11px;
+	font-size: 14px;
 	color: #64748b;
 	font-weight: 600;
-	padding-top: 4px;
-	min-width: 20px;
+	padding-top: 8px;
+	min-width: 28px;
 }
 .comment-text-input {
 	flex: 1;
-	padding: 4px 6px;
+	padding: 8px 10px;
 	border: 1px solid #cbd5e1;
-	border-radius: 4px;
-	font-size: 13px;
+	border-radius: 5px;
+	font-size: 15px;
 	resize: vertical;
-	min-height: 28px;
+	min-height: 42px;
+	font-family: inherit;
+}
+.comment-text-input:focus {
+	outline: none;
+	border-color: #3b82f6;
+	box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
 .comment-delete {
-	padding: 2px 8px;
+	padding: 6px 12px;
 	line-height: 1;
+	font-size: 16px;
 }
 .comment-entry-controls {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8px;
+	gap: 10px;
 	align-items: center;
 }
 .comment-control {
 	display: inline-flex;
 	align-items: center;
-	gap: 4px;
-	font-size: 11px;
-	color: #606266;
+	gap: 6px;
+	font-size: 14px;
+	color: #475569;
+	font-weight: 500;
 }
 .comment-num-input {
-	width: 52px;
-	padding: 2px 4px;
-	font-size: 11px;
+	width: 64px;
+	padding: 6px 8px !important;
+	font-size: 14px !important;
+	border: 1px solid #cbd5e1 !important;
+	border-radius: 5px !important;
+	background: #fff !important;
+	color: #303133 !important;
+	box-sizing: border-box;
+	-moz-appearance: textfield;
+}
+.comment-num-input::-webkit-inner-spin-button,
+.comment-num-input::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+.comment-num-input:focus {
+	outline: none;
+	border-color: #3b82f6 !important;
+	box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
 .comments-actions {
 	display: flex;
@@ -3206,7 +3281,7 @@ img {
 	box-sizing: border-box;
 	user-select: none;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;   /* text flows from top of the box, not centered */
 	justify-content: center;
 	overflow: hidden;
 	background: rgba(255, 255, 255, 0.02);
@@ -3258,26 +3333,50 @@ img {
 .comment-rotate-handle:active {
 	cursor: grabbing;
 }
+.comment-resize-handle {
+	position: absolute;
+	right: -6px;
+	bottom: -6px;
+	width: 14px;
+	height: 14px;
+	border-radius: 3px;
+	background: #3b82f6;
+	border: 2px solid #fff;
+	cursor: nwse-resize;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+	z-index: 5;
+}
 
 /* Enhanced comment entry controls */
 .comment-control-wide {
 	flex: 1;
-	min-width: 130px;
+	min-width: 160px;
 }
 .comment-font-select {
-	font-size: 11px;
-	padding: 2px 4px;
+	font-size: 14px !important;
+	padding: 6px 10px !important;
 	width: 100%;
+	border: 1px solid #cbd5e1 !important;
+	border-radius: 5px !important;
+	background: #fff !important;
+	color: #303133 !important;
+	cursor: pointer;
+	box-sizing: border-box;
+}
+.comment-font-select:focus {
+	outline: none;
+	border-color: #3b82f6 !important;
+	box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
 .comment-style-btn {
-	width: 26px;
-	height: 26px;
+	width: 32px;
+	height: 32px;
 	padding: 0;
 	border: 1px solid #cbd5e1;
-	border-radius: 3px;
+	border-radius: 5px;
 	background: #fff;
 	cursor: pointer;
-	font-size: 12px;
+	font-size: 15px;
 	line-height: 1;
 	display: inline-flex;
 	align-items: center;
@@ -3292,27 +3391,27 @@ img {
 	background: #ecf5ff;
 }
 .comment-color-input {
-	width: 28px;
-	height: 26px;
-	padding: 0;
+	width: 36px;
+	height: 32px;
+	padding: 2px;
 	border: 1px solid #cbd5e1;
-	border-radius: 3px;
+	border-radius: 5px;
 	cursor: pointer;
 }
 .comment-align-group {
 	display: inline-flex;
 	border: 1px solid #cbd5e1;
-	border-radius: 3px;
+	border-radius: 5px;
 	overflow: hidden;
 }
 .comment-align-btn {
-	width: 26px;
-	height: 26px;
+	width: 32px;
+	height: 32px;
 	padding: 0;
 	border: none;
 	background: #fff;
 	cursor: pointer;
-	font-size: 11px;
+	font-size: 14px;
 	font-weight: 600;
 	border-right: 1px solid #cbd5e1;
 }
@@ -3328,7 +3427,7 @@ img {
 	box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.2);
 }
 .resize-hint {
-	font-size: 11px;
+	font-size: 14px;
 	color: #94a3b8;
 	font-style: italic;
 }

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -680,7 +680,9 @@ export default {
 			resize_mode: "Contain",
 			resize_fill_color: "#FFFFFF",
 			resize_flatten_rgb: true,
-			max_file_size_kb: 2048,
+			// max_file_size_kb intentionally NOT tracked in local state —
+			// it's a global Settings value enforced server-side when a
+			// batch is processed. Single-item uploads don't need it.
 			aspect_ratio_options: ["1:1", "4:3", "16:9", "3:2", "2:3", "Free"],
 			resize_mode_options: ["Contain", "Cover", "Stretch"],
 			// Live preview (new 2026-04) — rerenders on any resize param
@@ -791,7 +793,7 @@ export default {
 			this.resize_mode = this.resize_settings.resize_mode || "Contain";
 			this.resize_fill_color = this.resize_settings.resize_fill_color || "#FFFFFF";
 			this.resize_flatten_rgb = !!this.resize_settings.resize_flatten_rgb;
-			this.max_file_size_kb = this.resize_settings.max_file_size_kb || 2048;
+			// (max_file_size_kb is global Settings only; not read here)
 		}
 
 		// Comments: off by default on new uploads. The user has to opt in

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -3623,13 +3623,40 @@ img {
 
 /* Element UI's <el-image> mounts its image-viewer lightbox at
    document.body — it's not inside the Vue subtree so scoped styles
-   can't reach it. Bootstrap's modal uses z-index: 1055, so without
-   this bump the viewer opens UNDERNEATH the upload dialog and the
-   user can't interact with it. */
+   can't reach it. These rules apply globally and fix two issues:
+
+   1) z-index: the viewer defaults below Bootstrap's modal (1055)
+      so it opens UNDERNEATH the upload dialog. Bump to 2050.
+
+   2) Transparent PNG readability: by default the viewer shows the
+      image on a translucent dark mask — transparent pixels become
+      dark mask + whatever shows through. For product photos with
+      Remove BG, that makes edges hard to see against the backdrop.
+      Fix: OPAQUE dark mask (can't see through to the page below),
+      and a CHECKERBOARD background behind the image element so
+      the user can tell image pixels from transparent ones.
+      Same industry pattern as Photoshop / Figma / Photopea
+      "full-size transparent view". */
 .el-image-viewer__wrapper {
 	z-index: 2050 !important;
 }
 .el-image-viewer__mask {
 	z-index: 2049 !important;
+	background: #0f172a !important;   /* opaque slate-900 */
+	opacity: 1 !important;
+}
+.el-image-viewer__canvas .el-image-viewer__img {
+	/* Checkerboard baked into the img element's background so PNG
+	   transparency is distinguishable from the mask behind it. */
+	background-color: #ffffff;
+	background-image:
+		linear-gradient(45deg, #d1d5db 25%, transparent 25%),
+		linear-gradient(-45deg, #d1d5db 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #d1d5db 75%),
+		linear-gradient(-45deg, transparent 75%, #d1d5db 75%);
+	background-size: 20px 20px;
+	background-position: 0 0, 0 10px, 10px -10px, -10px 0;
+	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+	border-radius: 4px;
 }
 </style>

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -2232,9 +2232,9 @@ export default {
    Mobile: stacked (media query below flips to single-column). */
 .cropper-grid {
 	display: grid;
-	grid-template-columns: minmax(0, 1fr) minmax(320px, 400px);
+	grid-template-columns: minmax(0, 1fr) 420px;
 	grid-template-rows: 1fr auto;
-	gap: 16px;
+	gap: 20px;
 	align-items: stretch;
 	min-height: 0;
 }
@@ -2385,6 +2385,7 @@ img {
 .cropper-feature-tab-label {
 	font-weight: 600;
 	color: #303133;
+	font-size: 15px;
 }
 .cropper-feature-tab.active .cropper-feature-tab-label {
 	color: #3b82f6;
@@ -2392,14 +2393,14 @@ img {
 .cropper-feature-tab-state {
 	display: inline-flex;
 	align-items: center;
-	gap: 4px;
-	font-size: 10px;
-	font-weight: 700;
+	gap: 5px;
+	font-size: 13px;
+	font-weight: 600;
 	text-transform: uppercase;
 }
 .cropper-feature-tab-dot {
-	width: 6px;
-	height: 6px;
+	width: 8px;
+	height: 8px;
 	border-radius: 50%;
 	background: #cbd5e1;
 }
@@ -2438,7 +2439,7 @@ img {
 	background: #fafbfc;
 }
 .cropper-tab-enable-label {
-	font-size: 13px;
+	font-size: 16px;
 	font-weight: 600;
 	color: #303133;
 	display: inline-flex;
@@ -2446,11 +2447,11 @@ img {
 	gap: 8px;
 }
 .cropper-tab-enable-hint {
-	font-size: 11px;
+	font-size: 13px;
 	font-weight: 500;
 	color: var(--primary);
 	background: var(--control-bg, #e6f1fc);
-	padding: 2px 8px;
+	padding: 3px 10px;
 	border-radius: 10px;
 	animation: cropper-hint-pulse 1.4s ease-in-out infinite;
 }

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -544,14 +544,34 @@
 									/>
 								</label>
 							</div>
+
+							<!-- Per-box style save / reset: applies to the
+							     currently-selected box only. Persists the 6
+							     style fields (font / size / weight / style /
+							     color / align) to Image Processing Settings
+							     as the new "default style for new boxes". -->
+							<div class="comment-entry-actions">
+								<button type="button" class="btn btn-xs btn-default" @click.stop="_reset_comment_style(i)">
+									{{ __("Reset Style") }}
+								</button>
+								<button type="button" class="btn btn-xs btn-primary-light" @click.stop="_save_comment_style(i)">
+									{{ __("Save Style as Default") }}
+								</button>
+							</div>
 						</div>
 
+						<!-- Panel-level save / reset: captures the full
+						     Comments tab state (enable flag + current box
+						     list) into Image Processing Settings so the
+						     next upload / batch / row opens with the same
+						     defaults. Mirrors Remove BG / Watermark /
+						     Canvas tab-level save. -->
 						<div class="wm-panel-actions">
-							<button class="btn btn-xs btn-default" @click="_reset_comments_to_defaults">
+							<button class="btn btn-xs btn-default" @click="_reset_comments_panel">
 								{{ __("Reset") }}
 							</button>
-							<button class="btn btn-xs btn-primary-light" @click="_save_comment_defaults">
-								{{ __("Save Style as Default") }}
+							<button class="btn btn-xs btn-primary-light" @click="_save_comments_panel">
+								{{ __("Save as Default") }}
 							</button>
 						</div>
 					</div>
@@ -667,6 +687,10 @@ export default {
 		// textarea-based editor (no drag). Batch flow uses the full
 		// CommentBoxEditor with draggable handles.
 		"show_comments", "comment_defaults", "comment_presets", "comments_default_enabled",
+		// Carry-over from Step 1's sidebar-only CommentBoxEditor: any
+		// box list the user built before picking a file starts life
+		// here inside the cropper so they don't have to re-enter it.
+		"initial_comment_boxes",
 	],
 	data() {
 		return {
@@ -897,8 +921,20 @@ export default {
 		// has to opt in either on the file-picker page or via the tab.
 		if (this.show_comments) {
 			this.comments_enabled = !!this.comments_default_enabled;
+			// Seed the comment list. Priority:
+			//   1. initial_comment_boxes (carried over from Step 1's
+			//      sidebar-only CommentBoxEditor — user's pre-file-pick
+			//      edits take precedence)
+			//   2. Settings.comment_presets (global default)
+			//   3. empty list
+			// Deep-clone in either case to avoid sharing refs with the
+			// caller's array.
+			if (Array.isArray(this.initial_comment_boxes) && this.initial_comment_boxes.length) {
+				this.comment_boxes = this.initial_comment_boxes.map((p) => ({ ...p }));
+			} else if (Array.isArray(this.comment_presets) && this.comment_presets.length) {
+				this.comment_boxes = this.comment_presets.map((p) => ({ ...p }));
+			}
 		}
-		// comment_boxes starts empty; user adds them with + Add Comment.
 
 		// Global listeners for watermark drag
 		this._on_mousemove = this.on_wrapper_mousemove.bind(this);
@@ -1635,49 +1671,91 @@ export default {
 			}
 		},
 
-		// ── Reset / save comment-style defaults ──
-		_reset_comments_to_defaults() {
-			if (!this.comment_boxes.length) return;
-			const d = this.comment_defaults || {};
-			for (let i = 0; i < this.comment_boxes.length; i++) {
-				const box = this.comment_boxes[i];
-				this.$set(this.comment_boxes, i, {
-					...box,
-					font_family: d.font_family || "Arial",
-					font_size_pct: d.font_size_pct || 5.0,
-					font_weight: d.font_weight || "Normal",
-					font_style: d.font_style || "Normal",
-					color: d.color || "#000000",
-					align: d.align || "Center",
-				});
-			}
-		},
-		_save_comment_defaults() {
-			// Save the currently-selected box's style (or box #1's if none
-			// selected) as the new system-wide default via the Settings API.
-			const idx = this.selected_comment_idx >= 0 ? this.selected_comment_idx : 0;
-			const box = this.comment_boxes[idx];
-			if (!box) {
-				frappe.show_alert({ message: __("No comment to save as default"), indicator: "orange" });
-				return;
-			}
+		// ── Per-box style save / reset (Save Style as Default) ──
+		// Writes the 6 style fields of THIS box to Image Processing
+		// Settings' default_comment_*. Position / size / rotation / text
+		// stay per-box and are never part of the global default.
+		_save_comment_style(i) {
+			const box = this.comment_boxes[i];
+			if (!box) return;
 			frappe.call({
 				method: "frappe.client.set_value",
 				args: {
 					doctype: "Image Processing Settings",
 					name: "Image Processing Settings",
 					fieldname: {
-						default_comment_font_family: box.font_family,
-						default_comment_font_size_pct: box.font_size_pct,
-						default_comment_font_weight: box.font_weight,
-						default_comment_font_style: box.font_style,
-						default_comment_color: box.color,
-						default_comment_align: box.align,
+						default_comment_font_family: box.font_family || "Arial",
+						default_comment_font_size_pct: box.font_size_pct || 5.0,
+						default_comment_font_weight: box.font_weight || "Normal",
+						default_comment_font_style: box.font_style || "Normal",
+						default_comment_color: box.color || "#000000",
+						default_comment_align: box.align || "Center",
 					},
 				},
 				callback: () => {
-					frappe.show_alert({ message: __("Comment style saved as default"), indicator: "green" });
+					frappe.show_alert({
+						message: __("Comment style saved as default"),
+						indicator: "green",
+					});
 				},
+			});
+		},
+
+		// Reset THIS box's style fields back to comment_defaults (which
+		// mirrors Image Processing Settings' default_comment_*). Other
+		// fields (position, size, text) remain untouched.
+		_reset_comment_style(i) {
+			const box = this.comment_boxes[i];
+			if (!box) return;
+			const d = this.comment_defaults || {};
+			this.$set(this.comment_boxes, i, {
+				...box,
+				font_family: d.font_family || "Arial",
+				font_size_pct: d.font_size_pct || 5.0,
+				font_weight: d.font_weight || "Normal",
+				font_style: d.font_style || "Normal",
+				color: d.color || "#000000",
+				align: d.align || "Center",
+			});
+			frappe.show_alert({
+				message: __("Style reset to default"),
+				indicator: "blue",
+			});
+		},
+
+		// ── Panel-level save / reset (Save as Default) ──
+		// Writes the full Comments tab state — enable flag + whole
+		// box list — to Image Processing Settings via a single
+		// whitelisted endpoint. Matches the Save as Default button
+		// on Remove BG / Watermark / Canvas tabs.
+		_save_comments_panel() {
+			frappe.call({
+				method: "next.next.doctype.image_processing_settings.image_processing_settings.update_comment_presets",
+				args: {
+					presets_json: JSON.stringify(this.comment_boxes || []),
+					enabled: this.comments_enabled ? 1 : 0,
+				},
+				callback: () => {
+					frappe.show_alert({
+						message: __("Saved {0} comments as default", [this.comment_boxes.length]),
+						indicator: "green",
+					});
+				},
+			});
+		},
+
+		// Reset the panel — replace box list with the current
+		// comment_presets prop (which is the singleton's saved list).
+		// Also flips the enable toggle back to the saved default.
+		_reset_comments_panel() {
+			this.comment_boxes = Array.isArray(this.comment_presets)
+				? this.comment_presets.map((p) => ({ ...p }))
+				: [];
+			this.selected_comment_idx = -1;
+			this.comments_enabled = !!this.comments_default_enabled;
+			frappe.show_alert({
+				message: __("Reset to saved defaults"),
+				indicator: "blue",
 			});
 		},
 
@@ -2475,12 +2553,16 @@ img {
 	gap: 8px;
 	margin-left: auto;
 }
+/* Match the Item Image Batch row thumbnail styling: transparent
+   background, contain-fit img, hover highlights. No colored box
+   around the thumb — transparent PNG shows as transparent (user
+   can zoom into the lightbox for full-resolution inspection with
+   checkerboard backing). */
 .cropper-preview-canvas,
 .cropper-preview-elimage {
 	width: 50px;
 	height: 50px;
 	border-radius: 6px;
-	background: #2c2c2c;
 	overflow: hidden;
 	display: block;
 	cursor: zoom-in;
@@ -2488,10 +2570,6 @@ img {
 	flex-shrink: 0;
 }
 .cropper-preview-canvas {
-	/* Fallback canvas before the first data URL lands in el-image.
-	   _render_preview sets internal .width/height and style.width/
-	   height directly on this canvas, so we leave those auto and
-	   only size the outer box. */
 	max-width: 50px;
 	max-height: 50px;
 }
@@ -2504,13 +2582,17 @@ img {
 	object-fit: contain;
 	width: 100%;
 	height: 100%;
+	background: transparent;
 }
-/* Mini spinner that replaces the thumb while Remove BG is running. */
+/* Mini spinner that replaces the thumb while Remove BG is running.
+   Dark backing only HERE because a spinner needs contrast — the
+   actual preview image uses transparent. */
 .cropper-toolbar-preview-spinner {
 	width: 50px;
 	height: 50px;
 	border-radius: 6px;
-	background: #2c2c2c;
+	background: #f1f5f9;
+	border: 1px solid var(--border-color);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -3378,6 +3460,15 @@ img {
 	gap: 10px;
 	align-items: center;
 }
+/* Per-box action row (Reset Style / Save Style as Default). */
+.comment-entry-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 8px;
+	padding-top: 8px;
+	border-top: 1px dashed #e2e8f0;
+}
 .comment-control {
 	display: inline-flex;
 	align-items: center;
@@ -3623,31 +3714,27 @@ img {
 
 /* Element UI's <el-image> mounts its image-viewer lightbox at
    document.body — it's not inside the Vue subtree so scoped styles
-   can't reach it. These rules apply globally and fix two issues:
+   can't reach it. Bootstrap's modal uses z-index: 1055, so without
+   this bump the viewer opens UNDERNEATH the upload dialog and the
+   user can't interact with it.
 
-   1) z-index: the viewer defaults below Bootstrap's modal (1055)
-      so it opens UNDERNEATH the upload dialog. Bump to 2050.
-
-   2) Transparent PNG readability: by default the viewer shows the
-      image on a translucent dark mask — transparent pixels become
-      dark mask + whatever shows through. For product photos with
-      Remove BG, that makes edges hard to see against the backdrop.
-      Fix: OPAQUE dark mask (can't see through to the page below),
-      and a CHECKERBOARD background behind the image element so
-      the user can tell image pixels from transparent ones.
-      Same industry pattern as Photoshop / Figma / Photopea
-      "full-size transparent view". */
+   NOTE: do NOT override .el-image-viewer__mask's background or
+   opacity — that element is the full-viewport positioning container
+   for the img, so backgrounding it paints over the image too. The
+   mask's default translucent black is already fine for a lightbox.
+   For transparent-PNG readability we add checkerboard to the img
+   itself below. */
 .el-image-viewer__wrapper {
 	z-index: 2050 !important;
 }
 .el-image-viewer__mask {
 	z-index: 2049 !important;
-	background: #0f172a !important;   /* opaque slate-900 */
-	opacity: 1 !important;
 }
 .el-image-viewer__canvas .el-image-viewer__img {
-	/* Checkerboard baked into the img element's background so PNG
-	   transparency is distinguishable from the mask behind it. */
+	/* Checkerboard baked into the img element so PNG transparency is
+	   visible in the lightbox. The img has its own pixel data on top,
+	   so the checker only shows through transparent regions — same
+	   pattern Photoshop / Figma / Photopea use for transparent view. */
 	background-color: #ffffff;
 	background-image:
 		linear-gradient(45deg, #d1d5db 25%, transparent 25%),

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -129,30 +129,25 @@
 				</div>
 			</div>
 
-			<!-- Preview strip: dedicated row under the cropper. Label on top
-			     acts as the visual divider; thumbnail centered underneath
-			     at 1:1 height with the cropper above. The thumb is an
-			     <el-image> with preview-src-list so click opens Element
-			     UI's image-viewer (zoom / rotate / pan). El-image lazy-
-			     renders an img from the data URL produced by the preview
-			     pipeline, which we refresh every time Canvas settings
-			     change via _refresh_preview_src(). -->
-			<div class="cropper-preview-bar" v-if="any_feature_on">
-				<div class="cropper-preview-header">
-					<span class="cropper-preview-title">{{ __("Preview") }}</span>
-					<span class="cropper-preview-hint">{{ __("final output after Crop") }}</span>
-				</div>
-				<div class="cropper-preview-thumb">
-					<canvas ref="preview_canvas" class="resize-preview-canvas" :class="{ 'el-image-backed': !!_preview_data_url }"></canvas>
-					<el-image
-						v-if="_preview_data_url"
-						class="cropper-preview-elimage"
-						:src="_preview_data_url"
-						:preview-src-list="[_preview_data_url]"
-						fit="contain"
-					/>
-				</div>
-			</div>
+			<!-- Preview — compact 400×400 thumb that matches the Item
+			     Image Batch row-thumbnail pattern. No outer card /
+			     header wrapper: the <el-image> is the whole thing,
+			     sitting directly in the left-col flex flow. Click
+			     opens Element UI's image-viewer lightbox. -->
+			<template v-if="any_feature_on">
+				<canvas
+					ref="preview_canvas"
+					class="cropper-preview-canvas"
+					:class="{ 'el-image-backed': !!_preview_data_url }"
+				></canvas>
+				<el-image
+					v-if="_preview_data_url"
+					class="cropper-preview-elimage"
+					:src="_preview_data_url"
+					:preview-src-list="[_preview_data_url]"
+					fit="contain"
+				/>
+			</template>
 
 		</div>
 
@@ -2388,79 +2383,33 @@ img {
 	max-height: min(600px, calc(100vh - 320px));
 }
 
-/* ── Preview bar below cropper ────────────────────────────────────
-   Dedicated section below the cropper acting as a visual divider —
-   header on top, thumbnail centered. Sized equally with
-   .cropper-image-wrapper above (flex:1 each) so "edit area" and
-   "preview" mirror each other. */
-.cropper-preview-bar {
-	display: flex;
-	flex-direction: column;
-	gap: 10px;
-	padding: 12px 14px;
-	border: 1px solid var(--border-color);
-	border-radius: 8px;
-	background: var(--fg-color, white);
-	align-items: stretch;
-	flex: 1 1 0;
-	min-height: 0;
-	overflow: hidden;
-}
-.cropper-preview-header {
-	display: flex;
-	align-items: baseline;
-	gap: 8px;
-	padding-bottom: 8px;
-	border-bottom: 1px solid var(--border-color);
+/* ── Preview thumb below cropper ──────────────────────────────────
+   Bare 400×400 el-image, no outer card / header wrapper. Sits
+   directly in the left-col flex flow, left-aligned. Matches the
+   Item Image Batch row-thumbnail visual language (deep background,
+   rounded corners, zoom-on-hover). Click → Element UI image-viewer. */
+.cropper-preview-canvas,
+.cropper-preview-elimage {
+	align-self: flex-start;
+	width: 400px;
+	height: 400px;
 	flex-shrink: 0;
-}
-.cropper-preview-title {
-	font-weight: 600;
-	font-size: 15px;
-	color: #303133;
-}
-.cropper-preview-hint {
-	font-weight: 400;
-	font-size: 13px;
-	color: #94a3b8;
-}
-.cropper-preview-thumb {
-	position: relative;
-	flex: 1 1 auto;
-	min-height: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	border: 1px solid var(--border-color);
-	border-radius: 6px;
-	background: #ffffff;
-	background-image:
-		linear-gradient(45deg, #f0f0f0 25%, transparent 25%),
-		linear-gradient(-45deg, #f0f0f0 25%, transparent 25%),
-		linear-gradient(45deg, transparent 75%, #f0f0f0 75%),
-		linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
-	background-size: 12px 12px;
-	background-position: 0 0, 0 6px, 6px -6px, -6px 0;
+	border-radius: 8px;
+	background: #2c2c2c;
 	overflow: hidden;
+	display: block;
+	cursor: zoom-in;
+	transition: box-shadow 0.15s ease, transform 0.12s ease;
 }
-/* Fallback canvas shown until the <el-image> mounts its img (first
-   _render_preview populates _preview_data_url → el-image takes over). */
-.cropper-preview-thumb canvas {
+.cropper-preview-canvas {
+	/* Fallback before el-image mounts with the first data URL. */
 	max-width: 100%;
 	max-height: 100%;
-	width: auto;
-	height: auto;
-	display: block;
 }
-/* Hide the canvas once el-image has an src — el-image handles rendering
-   AND the zoom-viewer lifecycle, so showing both would double-draw. */
-.cropper-preview-thumb canvas.el-image-backed { display: none; }
-/* el-image fills the thumb container and provides its own preview
-   behaviour — preview-src-list spins up el-image-viewer on click. */
-.cropper-preview-elimage {
-	width: 100%;
-	height: 100%;
-	cursor: zoom-in;
+.cropper-preview-canvas.el-image-backed { display: none; }
+.cropper-preview-elimage:hover {
+	box-shadow: 0 0 0 2px var(--primary, #2563eb), 0 6px 14px rgba(37, 99, 235, 0.2);
+	transform: scale(1.01);
 }
 .cropper-preview-elimage >>> .el-image__inner {
 	object-fit: contain;
@@ -2666,27 +2615,25 @@ img {
 }
 
 /* ── Mobile: stack left + right columns ──
-   Grid collapses to one column and rows auto-stretch. The cropper
-   wrapper and preview bar keep the 1:1 flex ratio inside left-col,
-   and the right panel stacks below at its natural height. The
-   whole page is vertically scrollable so on phones the user sees
-   cropper → preview → params → Crop button by scrolling. */
+   Grid collapses to one column. Cropper stays dominant (~60vh),
+   preview becomes a compact row with a 160×160 thumb. Right panel
+   scrolls naturally with the page so user sees
+   cropper → preview → params → Crop. */
 @media (max-width: 900px) {
 	.cropper-grid {
 		grid-template-columns: 1fr;
 		grid-template-rows: auto auto auto;
 		height: auto;
 	}
-	.cropper-left-col {
-		/* On mobile, cropper + preview each take 40vh so both are visible
-		   at once without forcing a huge viewport. Together with the
-		   right-col and action bar they fit a normal phone viewport. */
-		min-height: 80vh;
+	.cropper-left-col { min-height: 0; }
+	.cropper-image-wrapper {
+		flex: 0 0 auto;
+		min-height: 60vh;
 	}
-	.cropper-image-wrapper,
-	.cropper-preview-bar {
-		flex: 1 1 40vh;
-		min-height: 40vh;
+	.cropper-preview-canvas,
+	.cropper-preview-elimage {
+		width: 260px;
+		height: 260px;
 	}
 	.cropper-right-col {
 		max-height: none;
@@ -2701,16 +2648,14 @@ img {
 	.wm-slider-row .wm-slider-label { width: 82px; font-size: 13px; }
 	.wm-slider-row .wm-slider-value { width: 44px; font-size: 12px; }
 	.segmented-tab { padding: 7px 12px; font-size: 13px; }
-	.cropper-preview-thumb canvas { max-width: 100%; max-height: 100%; }
 }
 @media (max-width: 480px) {
-	/* Very small phones — shrink each row further so all 3 sections
-	   still fit in a single swipe. */
-	.cropper-left-col { min-height: 72vh; }
-	.cropper-image-wrapper,
-	.cropper-preview-bar {
-		flex: 1 1 36vh;
-		min-height: 36vh;
+	/* Very small phones — smaller cropper + thumb to fit a single swipe. */
+	.cropper-image-wrapper { min-height: 50vh; }
+	.cropper-preview-canvas,
+	.cropper-preview-elimage {
+		width: 180px;
+		height: 180px;
 	}
 }
 
@@ -2838,9 +2783,17 @@ img {
 
 .cropper-image-wrapper {
 	position: relative;
-	flex: 1 1 0;   /* equal share with .cropper-preview-bar below (flex:1 each = 1:1) */
+	/* Cropper dominates the left column — takes remaining height
+	   above the fixed-size preview thumb. Deep neutral background
+	   (Photopea / Figma palette) so both colored photos and
+	   transparent PNGs read clearly; PNG transparency shows as
+	   the same dark gray, and Canvas output with solid fill shows
+	   the fill color, making the two states easy to distinguish. */
+	flex: 1 1 auto;
 	min-height: 0;
 	overflow: hidden;
+	background: #2c2c2c;
+	border-radius: 8px;
 }
 .cropper-image-wrapper img {
 	max-width: 100%;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -230,14 +230,17 @@
 				<!-- REMOVE BG TAB -->
 				<div v-show="active_tab === 'remove_bg'" class="cropper-tab-pane">
 					<div class="cropper-tab-enable">
-						<span class="cropper-tab-enable-label">{{ __("Enable Remove Background") }}</span>
+						<span class="cropper-tab-enable-label">
+							{{ __("Enable Remove Background") }}
+							<span v-if="bg_processing" class="cropper-tab-enable-hint">{{ __("Processing…") }}</span>
+						</span>
 						<div
 							class="toggle-pill toggle-pill-compact"
-							:class="{ active: bg_removed, processing: bg_processing }"
+							:class="{ active: bg_removed || bg_processing, processing: bg_processing }"
 							@click="toggle_remove_bg"
 						>
 							<span class="toggle-pill-switch">
-								<span class="toggle-pill-track" :class="{ on: bg_removed }">
+								<span class="toggle-pill-track" :class="{ on: bg_removed || bg_processing }">
 									<span class="toggle-pill-thumb"></span>
 								</span>
 							</span>
@@ -644,12 +647,12 @@ export default {
 		"show_remove_bg", "remove_bg_checked", "remove_bg_padding_pct",
 		"show_watermark", "watermark_settings", "wm_default_enabled",
 		// Resize (new 2026-04) — from Image Processing Settings via item.js
-		"show_resize", "resize_settings",
+		"show_resize", "resize_settings", "resize_default_enabled",
 		// Comments (new 2026-04) — simple list of text overlays baked into
 		// the final output. The single-item flow uses a lightweight
 		// textarea-based editor (no drag). Batch flow uses the full
 		// CommentBoxEditor with draggable handles.
-		"show_comments", "comment_defaults", "comment_presets",
+		"show_comments", "comment_defaults", "comment_presets", "comments_default_enabled",
 	],
 	data() {
 		return {
@@ -741,7 +744,14 @@ export default {
 		},
 		// Any change to resize params → rerender the preview. Debounced
 		// so slider drags don't hammer the off-screen canvas composite.
-		resize_enabled() { this._schedule_preview_update(); },
+		resize_enabled(v) {
+			this._schedule_preview_update();
+			this.$emit("resize_enabled_changed", !!v);
+		},
+		comments_enabled(v) {
+			this._schedule_preview_update();
+			this.$emit("comments_enabled_changed", !!v);
+		},
 		resize_aspect() { this._schedule_preview_update(); },
 		resize_mode() { this._schedule_preview_update(); },
 		resize_fill_color() { this._schedule_preview_update(); },
@@ -812,9 +822,13 @@ export default {
 			this.load_watermark_image(this.watermark_settings.watermark_image);
 		}
 
-		// Resize: load settings (new 2026-04)
+		// Resize: load settings (new 2026-04). The pre-cropper footer
+		// toggle (resize_default_enabled) wins over Settings so a user
+		// who flipped Canvas off on the file-picker page stays off.
 		if (this.show_resize && this.resize_settings) {
-			this.resize_enabled = !!this.resize_settings.resize_enabled;
+			this.resize_enabled = this.resize_default_enabled != null
+				? !!this.resize_default_enabled
+				: !!this.resize_settings.resize_enabled;
 			this.resize_aspect = this.resize_settings.resize_aspect || "1:1";
 			this.resize_mode = this.resize_settings.resize_mode || "Contain";
 			this.resize_fill_color = this.resize_settings.resize_fill_color || "#FFFFFF";
@@ -822,10 +836,13 @@ export default {
 			// (max_file_size_kb is global Settings only; not read here)
 		}
 
-		// Comments: off by default on new uploads. The user has to opt in
-		// each time (unlike Resize which follows the Settings default)
-		// because comments carry meaning — users shouldn't accidentally
-		// bake a previous session's text onto a new photo.
+		// Comments: off by default on new uploads unless the footer
+		// toggle is ON. Comments carry meaning, so we don't silently
+		// bake a previous session's text onto a new photo — the user
+		// has to opt in either on the file-picker page or via the tab.
+		if (this.show_comments) {
+			this.comments_enabled = !!this.comments_default_enabled;
+		}
 		// comment_boxes starts empty; user adds them with + Add Comment.
 
 		// Global listeners for watermark drag
@@ -2417,6 +2434,29 @@ img {
 	font-size: 13px;
 	font-weight: 600;
 	color: #303133;
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+.cropper-tab-enable-hint {
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--primary);
+	background: var(--control-bg, #e6f1fc);
+	padding: 2px 8px;
+	border-radius: 10px;
+	animation: cropper-hint-pulse 1.4s ease-in-out infinite;
+}
+@keyframes cropper-hint-pulse {
+	0%, 100% { opacity: 0.65; }
+	50% { opacity: 1; }
+}
+.toggle-pill-compact.processing {
+	cursor: not-allowed;
+	pointer-events: none;
+}
+.toggle-pill-compact.processing .toggle-pill-track {
+	animation: cropper-hint-pulse 1.4s ease-in-out infinite;
 }
 .toggle-pill-compact {
 	padding: 0;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1237,6 +1237,20 @@ export default {
 				}
 				this.file.file_obj = new File([blob], name, { type: blob.type });
 				this.file.name = name;
+				// Emit the final settings snapshot so FileUploader's Step 3
+				// recap card shows the exact values the user baked into the
+				// file (not the Step 1 defaults, which may have been
+				// overridden inside the cropper).
+				this.$emit("crop_committed", {
+					remove_bg: !!this.bg_removed,
+					watermark_enabled: !!this.wm_enabled,
+					watermark_mode: this.wm_mode,
+					comments_enabled: !!this.comments_enabled,
+					comment_count: (this.comment_boxes || []).length,
+					resize_enabled: !!this.resize_enabled,
+					resize_aspect: this.resize_aspect,
+					resize_mode: this.resize_mode,
+				});
 				this.$emit("toggle_image_cropper");
 			}, file_type, file_type === "image/jpeg" ? 0.92 : undefined);
 		},

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1410,8 +1410,27 @@ export default {
 					remove_bg: !!this.bg_removed,
 					watermark_enabled: !!this.wm_enabled,
 					watermark_mode: this.wm_mode,
+					// Full watermark state so re-opening the cropper
+					// after Step 3 restores opacity / size / position /
+					// rotation / tile params instead of resetting to
+					// Settings defaults.
+					watermark_state: {
+						mode: this.wm_mode,
+						position_x: this.wm_pos_x,
+						position_y: this.wm_pos_y,
+						size: this.wm_size,
+						opacity: this.wm_opacity,
+						corner_rotation: this.wm_corner_rotation,
+						tile_size: this.wm_tile_size,
+						tile_opacity: this.wm_tile_opacity,
+						tile_rotation: this.wm_tile_rotation,
+						tile_spacing: this.wm_tile_spacing,
+					},
 					comments_enabled: !!this.comments_enabled,
 					comment_count: (this.comment_boxes || []).length,
+					// Deep-clone so FileUploader can mutate without
+					// reaching back into the cropper's reactive state.
+					comment_boxes: (this.comment_boxes || []).map((b) => ({ ...b })),
 					crop_aspect: this._aspect_number_to_string(this.aspect_ratio),
 					solid_background: !!this.solid_background,
 					background_color: this.background_color,

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -2,49 +2,10 @@
 	<div class="cropper-grid">
 		<!-- LEFT COLUMN: toolbar + cropper + preview + action buttons -->
 		<div class="cropper-left-col">
-			<!-- Top toolbar: Drag mode (crop/watermark/comment) + Crop ratio.
-			     Wraps to 2 rows on narrow screens. -->
+			<!-- Top toolbar: Crop ratio only. Drag mode tabs are gone —
+			     elements are selected by clicking them (comment box,
+			     watermark rect, or crop frame) and dragged in place. -->
 			<div class="cropper-top-toolbar">
-				<div class="cropper-toolbar-group" v-if="show_drag_mode_tabs">
-					<span class="cropper-toolbar-label">{{ __("Drag") }}:</span>
-					<div class="segmented-tabs" role="tablist">
-						<button
-							class="segmented-tab"
-							:class="{ active: interaction_mode === 'crop' }"
-							role="tab"
-							:aria-selected="interaction_mode === 'crop'"
-							:title="__('Drag to resize/move the crop box')"
-							@click="set_mode('crop')"
-						>
-							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 2v14a2 2 0 002 2h14"/><path d="M18 22V8a2 2 0 00-2-2H2"/></svg>
-							{{ __("Crop box") }}
-						</button>
-						<button
-							v-if="show_watermark && wm_enabled && wm_loaded && wm_mode === 'Corner'"
-							class="segmented-tab"
-							:class="{ active: interaction_mode === 'watermark' }"
-							role="tab"
-							:aria-selected="interaction_mode === 'watermark'"
-							:title="__('Drag to move the watermark logo')"
-							@click="set_mode('watermark')"
-						>
-							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
-							{{ __("Watermark") }}
-						</button>
-						<button
-							v-if="show_comments && comments_enabled && comment_boxes.length > 0"
-							class="segmented-tab"
-							:class="{ active: interaction_mode === 'comment' }"
-							role="tab"
-							:aria-selected="interaction_mode === 'comment'"
-							:title="__('Drag to move text comments')"
-							@click="set_mode('comment')"
-						>
-							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-							{{ __("Comment") }}
-						</button>
-					</div>
-				</div>
 				<div class="cropper-toolbar-group" v-if="fixed_aspect_ratio == null">
 					<span class="cropper-toolbar-label">{{ __("Crop ratio") }}:</span>
 					<div class="btn-group btn-group-sm">
@@ -125,8 +86,6 @@
 					class="cropper-image-wrapper"
 					ref="wrapper"
 					:class="{
-						'wm-mode': interaction_mode === 'watermark' && wm_mode === 'Corner',
-						'comment-mode': interaction_mode === 'comment',
 						'bg-processing': bg_processing,
 					}"
 					@mousedown="on_wrapper_mousedown"
@@ -138,7 +97,7 @@
 					v-if="wm_enabled && wm_loaded"
 					ref="wm_canvas"
 					class="watermark-overlay-canvas"
-					:style="{ pointerEvents: (interaction_mode === 'watermark' && wm_mode === 'Corner') ? 'auto' : 'none' }"
+					style="pointer-events: none;"
 				></canvas>
 				<!-- Comment overlay: DOM boxes drawn on top of the image so
 				     the user can see text positioning + drag them. -->
@@ -164,13 +123,13 @@
 							{{ box.text || __('(empty)') }}
 						</div>
 						<div
-							v-if="selected_comment_idx === i && interaction_mode === 'comment'"
+							v-if="selected_comment_idx === i && selected_type === 'comment'"
 							class="comment-rotate-handle"
 							:title="__('Rotate')"
 							@mousedown.stop="on_comment_rotate_mousedown($event, i)"
 						>↻</div>
 						<div
-							v-if="selected_comment_idx === i && interaction_mode === 'comment'"
+							v-if="selected_comment_idx === i && selected_type === 'comment'"
 							class="comment-resize-handle"
 							:title="__('Resize')"
 							@mousedown.stop="on_comment_resize_mousedown($event, i)"
@@ -760,8 +719,11 @@ export default {
 			wm_tile_opacity: 12,
 			wm_tile_rotation: -30,
 			wm_tile_spacing: 40,
-			// Interaction mode
-			interaction_mode: "crop",
+			// What's currently selected on the canvas: 'crop' | 'watermark'
+			// | 'comment'. Drives handle + outline visibility; does NOT
+			// gate drag permissions — every overlay element captures its
+			// own events regardless of selected_type.
+			selected_type: "crop",
 			// Output Shape (new 2026-04) — baked into the final cropped canvas
 			// before upload. Same logic as the server-side PIL helper in
 			// item_image_batch.py::_apply_aspect_normalize.
@@ -794,7 +756,11 @@ export default {
 			_comment_drag_start: null,
 			// Canvas data cache (image display rect in cropper wrapper)
 			// updated on cropper ready + crop event for overlay positioning.
-			_canvas_data: null,
+			// NB: no leading underscore — Vue 2 skips reactivity proxying for
+			// keys starting with `_` or `$`, so an underscore-prefixed data
+			// key would never trigger re-render of the comment_overlay_style
+			// / comment_text_style computeds that read it.
+			canvas_data: null,
 			comment_font_families: [
 				"Arial", "Helvetica", "Times New Roman",
 				"Courier New", "Georgia", "Verdana",
@@ -1109,7 +1075,7 @@ export default {
 		// the cropper wrapper as a whole). Position it via the cropper's
 		// getCanvasData() output so it tracks zoom + pan.
 		comment_overlay_style() {
-			const cd = this._canvas_data;
+			const cd = this.canvas_data;
 			if (!cd) return { display: "none" };
 			return {
 				position: "absolute",
@@ -1117,9 +1083,12 @@ export default {
 				top: cd.top + "px",
 				width: cd.width + "px",
 				height: cd.height + "px",
-				// pointerEvents only active when user is in comment mode,
-				// so watermark + crop drag still work from the same pixels.
-				pointerEvents: this.interaction_mode === "comment" ? "auto" : "none",
+				// Container is transparent to pointer events; each
+				// .comment-overlay-box re-enables them inside its own rect.
+				// That way clicking empty overlay passes through to the
+				// cropper (so you can still resize/move crop through areas
+				// that would otherwise be covered by comment mode).
+				pointerEvents: "none",
 			};
 		},
 
@@ -1142,13 +1111,6 @@ export default {
 		any_feature_shown() {
 			return !!(this.show_remove_bg || this.show_watermark ||
 			          this.show_comments || this.show_resize);
-		},
-
-		// Whether to show the 'Drag:' tab row above the cropper. Always
-		// rendered so toggling watermark / comment on doesn't cause the
-		// layout to shift — the 'Crop box' button is always visible.
-		show_drag_mode_tabs() {
-			return true;
 		},
 
 		// Human-readable output format label for the preview chip.
@@ -1509,7 +1471,7 @@ export default {
 			};
 		},
 		comment_text_style(box) {
-			const cd = this._canvas_data;
+			const cd = this.canvas_data;
 			// Compute px font size from the displayed image height, not
 			// the natural size (so on-screen text matches what user sees
 			// in the preview).
@@ -1530,15 +1492,20 @@ export default {
 		_update_canvas_data() {
 			if (!this.cropper) return;
 			try {
-				this._canvas_data = this.cropper.getCanvasData();
+				this.canvas_data = this.cropper.getCanvasData();
 			} catch (e) {
-				this._canvas_data = null;
+				this.canvas_data = null;
 			}
 		},
 
 		// ── Comment drag handlers ──
+		// Point-to-drag: clicking a comment box selects it AND starts a
+		// drag in one gesture. The template's @mousedown.stop already
+		// prevents this event from reaching the wrapper (which would
+		// flip selected_type to 'crop'), so we don't need to
+		// stopPropagation manually.
 		on_comment_mousedown(e, i) {
-			if (this.interaction_mode !== "comment") return;
+			this.selected_type = "comment";
 			this.selected_comment_idx = i;
 			this.comment_dragging_idx = i;
 			const box = this.comment_boxes[i];
@@ -1552,7 +1519,7 @@ export default {
 			e.preventDefault();
 		},
 		on_comment_touchstart(e, i) {
-			if (this.interaction_mode !== "comment") return;
+			this.selected_type = "comment";
 			const t = e.touches[0];
 			this.selected_comment_idx = i;
 			this.comment_dragging_idx = i;
@@ -1566,8 +1533,9 @@ export default {
 			};
 		},
 		on_comment_rotate_mousedown(e, i) {
-			if (this.interaction_mode !== "comment") return;
-			const cd = this._canvas_data;
+			// Handle is only rendered when the box is already selected
+			// (see template v-if), so no need to re-check selected_type.
+			const cd = this.canvas_data;
 			const wrapper = this.$refs.wrapper;
 			if (!cd || !wrapper) return;
 			this.selected_comment_idx = i;
@@ -1588,8 +1556,8 @@ export default {
 			e.preventDefault();
 		},
 		on_comment_resize_mousedown(e, i) {
-			if (this.interaction_mode !== "comment") return;
-			const cd = this._canvas_data;
+			// Handle is only rendered when the box is already selected.
+			const cd = this.canvas_data;
 			if (!cd) return;
 			this.selected_comment_idx = i;
 			this.comment_dragging_idx = i;
@@ -1624,7 +1592,7 @@ export default {
 				return;
 			}
 
-			const cd = this._canvas_data;
+			const cd = this.canvas_data;
 			if (!cd) return;
 
 			if (start.mode === "resize") {
@@ -2246,7 +2214,7 @@ export default {
 			// Solid + thicker when interaction is set to "Move watermark", dashed
 			// and thinner otherwise so it still marks the watermark without
 			// screaming "drag me" when the user is cropping.
-			const active = this.interaction_mode === "watermark";
+			const active = this.selected_type === "watermark";
 			ctx.strokeStyle = active ? "rgba(59, 130, 246, 0.9)" : "rgba(59, 130, 246, 0.5)";
 			ctx.lineWidth = active ? 2 : 1;
 			if (!active) ctx.setLineDash([4, 4]);
@@ -2359,20 +2327,13 @@ export default {
 			this._zoom_preserving_crop(() => this.cropper.zoomTo(1));
 		},
 
-		set_mode(mode) {
-			this.interaction_mode = mode;
-			if (this.cropper) {
-				// Disable CropperJS drag in non-crop modes so the
-				// overlay elements (watermark canvas / comment DOM
-				// boxes) can capture mouse events without the crop
-				// box stealing them.
-				if (mode === "crop") {
-					this.cropper.setDragMode("crop");
-				} else {
-					this.cropper.setDragMode("none");
-				}
-			}
-			// Repaint watermark so the corner outline picks up the new active state.
+		// Deprecated drag-mode switcher kept as a thin setter for any
+		// lingering callers. Overlay elements now capture their own
+		// events (pointer-events scoped to each box/rect), so we don't
+		// need to toggle CropperJS drag mode — it can stay on 'crop'
+		// forever; empty overlay pixels fall through to it.
+		set_mode(type) {
+			this.selected_type = type;
 			if (this.wm_enabled && this.wm_loaded) {
 				this.$nextTick(() => this.wm_draw());
 			}
@@ -2383,21 +2344,37 @@ export default {
 		// there's no meaningful drag target; users adjust tile params via
 		// sliders instead.
 		on_wrapper_mousedown(e) {
-			if (this.interaction_mode !== "watermark") return;
-			if (this.wm_mode !== "Corner") return;
-			if (!this.wm_enabled || !this.wm_loaded || !this.cropper) return;
+			// Point-to-drag model: if the mousedown lands inside the
+			// watermark-Corner rect, we claim the event (drag watermark +
+			// mark it selected). Otherwise do nothing — let the event
+			// bubble to CropperJS, which will drag/resize the crop box,
+			// and flip selected_type back to 'crop' so watermark handles
+			// hide.
+			if (!this.cropper) return;
 			const canvas = this.$refs.wm_canvas;
-			if (!canvas) return;
-			const rect = canvas.getBoundingClientRect();
-			const mx = e.clientX - rect.left;
-			const my = e.clientY - rect.top;
-			const cd = this.cropper.getCanvasData();
-			e.stopPropagation();
-			e.preventDefault();
-			this.wm_dragging = true;
-			// Offset from watermark center in container coords
-			this.wm_drag_offset_x = mx - (cd.left + (this.wm_pos_x / 100) * cd.width);
-			this.wm_drag_offset_y = my - (cd.top + (this.wm_pos_y / 100) * cd.height);
+			const wrapper = this.$refs.wrapper;
+			if (!wrapper) return;
+			const wrapperRect = wrapper.getBoundingClientRect();
+			const mx = e.clientX - wrapperRect.left;
+			const my = e.clientY - wrapperRect.top;
+
+			const can_drag_wm = this.wm_enabled && this.wm_loaded
+				&& this.wm_mode === "Corner" && canvas;
+			if (can_drag_wm && this.wm_hit_test(mx, my)) {
+				e.stopPropagation();
+				e.preventDefault();
+				this.selected_type = "watermark";
+				this.selected_comment_idx = -1;
+				const cd = this.cropper.getCanvasData();
+				this.wm_dragging = true;
+				this.wm_drag_offset_x = mx - (cd.left + (this.wm_pos_x / 100) * cd.width);
+				this.wm_drag_offset_y = my - (cd.top + (this.wm_pos_y / 100) * cd.height);
+				this.wm_draw();
+				return;
+			}
+			// No overlay element under the cursor → CropperJS takes over.
+			this.selected_type = "crop";
+			this.selected_comment_idx = -1;
 		},
 		on_wrapper_mousemove(e) {
 			if (!this.wm_dragging || !this.cropper) return;
@@ -2419,7 +2396,7 @@ export default {
 		on_wrapper_wheel(e) {
 			// Watermark Corner mode: wheel resizes the draggable logo
 			// (size %). Keep the original behaviour.
-			if (this.interaction_mode === "watermark"
+			if (this.selected_type === "watermark"
 				&& this.wm_mode === "Corner"
 				&& this.wm_enabled
 				&& this.wm_loaded) {
@@ -2438,21 +2415,30 @@ export default {
 			}
 		},
 		on_wrapper_touchstart(e) {
-			if (this.interaction_mode !== "watermark") return;
-			if (this.wm_mode !== "Corner") return;
-			if (!this.wm_enabled || !this.wm_loaded || !this.cropper) return;
+			// Mirror on_wrapper_mousedown: only claim the touch if it
+			// lands inside the watermark rect. Otherwise the touch falls
+			// through to CropperJS.
+			if (!this.cropper) return;
 			const canvas = this.$refs.wm_canvas;
-			if (!canvas) return;
+			const wrapper = this.$refs.wrapper;
+			if (!wrapper) return;
+			const can_drag_wm = this.wm_enabled && this.wm_loaded
+				&& this.wm_mode === "Corner" && canvas;
+			if (!can_drag_wm) return;
 			const touch = e.touches[0];
-			const rect = canvas.getBoundingClientRect();
-			const mx = touch.clientX - rect.left;
-			const my = touch.clientY - rect.top;
-			const cd = this.cropper.getCanvasData();
+			const wrapperRect = wrapper.getBoundingClientRect();
+			const mx = touch.clientX - wrapperRect.left;
+			const my = touch.clientY - wrapperRect.top;
+			if (!this.wm_hit_test(mx, my)) return;
 			e.stopPropagation();
 			e.preventDefault();
+			this.selected_type = "watermark";
+			this.selected_comment_idx = -1;
+			const cd = this.cropper.getCanvasData();
 			this.wm_dragging = true;
 			this.wm_drag_offset_x = mx - (cd.left + (this.wm_pos_x / 100) * cd.width);
 			this.wm_drag_offset_y = my - (cd.top + (this.wm_pos_y / 100) * cd.height);
+			this.wm_draw();
 		},
 		on_wrapper_touchmove(e) {
 			if (!this.wm_dragging || !this.cropper) return;
@@ -2494,7 +2480,7 @@ export default {
 			this.wm_mode = mode;
 			// Tiled mode has no drag target — snap back to "Adjust crop box"
 			// interaction so the cursor + wrapper state stays consistent.
-			if (mode === "Tiled" && this.interaction_mode === "watermark") {
+			if (mode === "Tiled" && this.selected_type === "watermark") {
 				this.set_mode("crop");
 			}
 			this.wm_draw();
@@ -3123,10 +3109,6 @@ img {
 	display: block;
 }
 
-.cropper-image-wrapper.wm-mode {
-	cursor: move;
-}
-
 /* While Remove BG is running, hide CropperJS's own crop-box chrome so the
    user sees just the plain image + loading overlay. The crop box is
    meaningless during this ~10-second window (auto-crop will overwrite it
@@ -3669,32 +3651,35 @@ img {
 	border-bottom: none;
 }
 
-/* Draggable comment box overlay on the cropper image (new 2026-04) */
+/* Draggable comment box overlay on the cropper image.
+   Distinct emerald palette so comment boxes don't visually collide
+   with the crop rect (blue dashed) or the watermark rect (also blue).
+   Box itself owns pointer-events: auto so clicks anywhere inside it
+   start a drag, while the surrounding .comment-overlay container stays
+   transparent to events and falls through to CropperJS. */
 .comment-overlay {
 	pointer-events: none;
 }
 .comment-overlay-box {
 	position: absolute;
-	border: 1px dashed rgba(59, 130, 246, 0.5);
+	border: 1px dashed rgba(16, 185, 129, 0.65);
 	box-sizing: border-box;
 	user-select: none;
 	display: flex;
 	align-items: flex-start;   /* text flows from top of the box, not centered */
 	justify-content: center;
 	overflow: hidden;
-	background: rgba(255, 255, 255, 0.02);
-}
-.cropper-image-wrapper.comment-mode .comment-overlay-box {
+	background: rgba(16, 185, 129, 0.04);
+	pointer-events: auto;
 	cursor: move;
-	border-color: rgba(59, 130, 246, 0.75);
-	border-style: solid;
-	background: rgba(59, 130, 246, 0.04);
 }
-.cropper-image-wrapper.comment-mode .comment-overlay-box:hover {
-	background: rgba(59, 130, 246, 0.12);
+.comment-overlay-box:hover {
+	background: rgba(16, 185, 129, 0.1);
+	border-color: rgba(16, 185, 129, 0.9);
 }
 .comment-overlay-box.selected {
-	border: 2px solid #3b82f6;
+	border: 2px solid #10b981;
+	background: rgba(16, 185, 129, 0.08);
 }
 .comment-overlay-box.dragging {
 	opacity: 0.85;
@@ -3738,7 +3723,7 @@ img {
 	width: 14px;
 	height: 14px;
 	border-radius: 3px;
-	background: #3b82f6;
+	background: #10b981;
 	border: 2px solid #fff;
 	cursor: nwse-resize;
 	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -2750,6 +2750,14 @@ img {
 	cursor: zoom-in;
 	transition: box-shadow 0.15s ease, transform 0.12s ease;
 	flex-shrink: 0;
+	background-color: #fff;
+	background-image:
+		linear-gradient(45deg, #ccc 25%, transparent 25%),
+		linear-gradient(-45deg, #ccc 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #ccc 75%),
+		linear-gradient(-45deg, transparent 75%, #ccc 75%);
+	background-size: 10px 10px;
+	background-position: 0 0, 0 5px, 5px -5px, -5px 0;
 }
 .cropper-preview-canvas {
 	max-width: 50px;
@@ -3956,25 +3964,28 @@ img {
    this bump the viewer opens UNDERNEATH the upload dialog and the
    user can't interact with it.
 
-   NOTE: do NOT override .el-image-viewer__mask's background or
-   opacity — that element is the full-viewport positioning container
-   for the img, so backgrounding it paints over the image too. The
-   mask's default translucent black is already fine for a lightbox.
-   For transparent-PNG readability we add checkerboard to the img
-   itself below. */
+   Do NOT give .el-image-viewer__mask its own z-index. The mask is a
+   sibling of .el-image-viewer__canvas inside the wrapper; in default
+   DOM order mask renders first and canvas second, so the image sits
+   *on top* of the translucent black mask. Adding z-index to the mask
+   promotes it above the image (because canvas has no explicit z-index)
+   and the half-opaque black overlays the entire photo — which is what
+   made the preview look ~50% darker than the workspace. */
 .el-image-viewer__wrapper {
 	z-index: 2050 !important;
 }
-.el-image-viewer__mask {
-	z-index: 2049 !important;
-}
+/* Checkerboard behind transparent pixels so the lightbox matches the
+   CropperJS workspace (cropperjs/dist/images/bg.png — light gray on
+   white, 16×16 repeat). */
 .el-image-viewer__canvas .el-image-viewer__img {
-	/* Match the cropper workspace backdrop (#2c2c2c) so what the user
-	   sees in the thumb/lightbox is identical in colour to the cropper
-	   stage. No white fill and no checkerboard — the workspace itself
-	   doesn't show one either; the dark backdrop reads as "this area
-	   is transparent" by convention. */
-	background-color: #2c2c2c;
+	background-color: #fff;
+	background-image:
+		linear-gradient(45deg, #ccc 25%, transparent 25%),
+		linear-gradient(-45deg, #ccc 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #ccc 75%),
+		linear-gradient(-45deg, transparent 75%, #ccc 75%);
+	background-size: 16px 16px;
+	background-position: 0 0, 0 8px, 8px -8px, -8px 0;
 	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
 	border-radius: 4px;
 }

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -66,16 +66,27 @@
 
 				<!-- One Save-as-Default button persists the whole crop
 				     toolbar state (aspect + solid background + colour)
-				     onto Image Processing Settings. Hidden in fixed-ratio
+				     onto Image Processing Settings. Reset reverts the
+				     three values to whatever the uploader was opened
+				     with (prop values), mirroring Remove BG padding's
+				     Reset / Save-as-Default pair. Hidden in fixed-ratio
 				     batch flows since those rows don't edit defaults. -->
-				<button
-					v-if="fixed_aspect_ratio == null"
-					class="btn btn-xs btn-primary-light cropper-toolbar-save"
-					:title="__('Remember crop ratio, solid background, and colour as defaults for future uploads')"
-					@click="save_crop_defaults"
-				>
-					{{ __("Save as Default") }}
-				</button>
+				<template v-if="fixed_aspect_ratio == null">
+					<button
+						class="btn btn-xs btn-default cropper-toolbar-reset"
+						:title="__('Revert crop ratio, solid background, and colour to saved defaults')"
+						@click="reset_crop_defaults"
+					>
+						{{ __("Reset") }}
+					</button>
+					<button
+						class="btn btn-xs btn-primary-light cropper-toolbar-save"
+						:title="__('Remember crop ratio, solid background, and colour as defaults for future uploads')"
+						@click="save_crop_defaults"
+					>
+						{{ __("Save as Default") }}
+					</button>
+				</template>
 
 				<!-- Preview block inline in the toolbar, right-aligned via
 				     margin-left: auto so the full toolbar height stays
@@ -1300,6 +1311,24 @@ export default {
 			if (Math.abs(n - 4 / 3) < 1e-4) return "4:3";
 			if (Math.abs(n - 16 / 9) < 1e-4) return "16:9";
 			return "Free";
+		},
+
+		reset_crop_defaults() {
+			// Revert the three crop-toolbar values (aspect + solid bg
+			// + colour) to whatever the uploader was constructed with.
+			// Matches reset_padding_pct's "prop is source of truth"
+			// behaviour. No server round trip — just restore local state.
+			if (this.default_crop_aspect) {
+				this.aspect_ratio = this._aspect_string_to_number(this.default_crop_aspect);
+			} else {
+				this.aspect_ratio = NaN;
+			}
+			this.solid_background = !!this.default_solid_background;
+			this.background_color = this.default_background_color || "#FFFFFF";
+			frappe.show_alert({
+				message: __("Reset to saved defaults"),
+				indicator: "blue",
+			});
 		},
 
 		async save_crop_defaults() {

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -62,9 +62,62 @@
 		     Watermark) live in the sticky dialog footer; this panel only hosts
 		     the parameters for whichever features are currently on. -->
 		<div
-			v-if="(show_remove_bg && bg_removed && nobg_bbox) || (show_watermark && wm_enabled)"
+			v-if="(show_remove_bg && bg_removed && nobg_bbox) || (show_watermark && wm_enabled) || (show_resize && resize_enabled)"
 			class="adjustments-panel"
 		>
+			<!-- Output Shape (FIRST in list per UX spec) — aspect, mode, fill,
+			     flatten. Only shown when the Output Shape toggle pill is on. -->
+			<div
+				v-if="show_resize && resize_enabled"
+				class="adjustments-row adjustments-row-resize"
+			>
+				<label class="adjustments-field-label">
+					{{ __("Output Shape") }}
+					<span class="adjustments-field-hint">
+						{{ __("Aspect normalization baked on Crop. Never upscales.") }}
+					</span>
+				</label>
+				<div class="resize-tabs-row">
+					<span class="resize-sublabel">{{ __("Aspect") }}</span>
+					<div class="segmented-tabs" role="tablist">
+						<button
+							v-for="a in aspect_ratio_options"
+							:key="a"
+							class="segmented-tab"
+							:class="{ active: resize_aspect === a }"
+							@click="resize_aspect = a"
+						>{{ a }}</button>
+					</div>
+				</div>
+				<div class="resize-tabs-row">
+					<span class="resize-sublabel">{{ __("Mode") }}</span>
+					<div class="segmented-tabs" role="tablist">
+						<button
+							v-for="m in resize_mode_options"
+							:key="m"
+							class="segmented-tab"
+							:class="{ active: resize_mode === m, disabled: resize_aspect === 'Free' }"
+							:disabled="resize_aspect === 'Free'"
+							@click="resize_mode = m"
+						>{{ __(m) }}</button>
+					</div>
+				</div>
+				<div class="resize-misc-row">
+					<label class="resize-inline-field">
+						<span>{{ __("Fill") }}</span>
+						<input
+							type="color"
+							class="resize-color"
+							v-model="resize_fill_color"
+						/>
+					</label>
+					<label class="resize-inline-toggle">
+						<input type="checkbox" v-model="resize_flatten_rgb" />
+						<span>{{ __("Flatten RGB") }}</span>
+					</label>
+				</div>
+			</div>
+
 			<!-- Auto-crop padding (Remove BG) — only shown when Remove BG is on
 			     AND a bbox is available. -->
 			<div
@@ -252,6 +305,25 @@
 						</span>
 					</span>
 				</div>
+				<div
+					v-if="show_resize"
+					class="toggle-pill"
+					:class="{ active: resize_enabled }"
+					@click="resize_enabled = !resize_enabled"
+					:title="__('Normalize output aspect ({0}, {1})', [resize_aspect, resize_mode])"
+				>
+					<span class="toggle-pill-label">
+						{{ __("Output Shape") }}
+						<span v-if="resize_enabled" class="toggle-pill-sublabel">
+							{{ resize_aspect }}
+						</span>
+					</span>
+					<span class="toggle-pill-switch">
+						<span class="toggle-pill-track" :class="{ on: resize_enabled }">
+							<span class="toggle-pill-thumb"></span>
+						</span>
+					</span>
+				</div>
 			</div>
 			<div>
 				<button
@@ -277,6 +349,8 @@ export default {
 		"file", "fixed_aspect_ratio",
 		"show_remove_bg", "remove_bg_checked", "remove_bg_padding_pct",
 		"show_watermark", "watermark_settings", "wm_default_enabled",
+		// Output Shape (new 2026-04) — from Image Processing Settings via item.js
+		"show_resize", "resize_settings",
 	],
 	data() {
 		return {
@@ -320,6 +394,17 @@ export default {
 			wm_tile_spacing: 40,
 			// Interaction mode
 			interaction_mode: "crop",
+			// Output Shape (new 2026-04) — baked into the final cropped canvas
+			// before upload. Same logic as the server-side PIL helper in
+			// item_image_batch.py::_apply_aspect_normalize.
+			resize_enabled: false,
+			resize_aspect: "1:1",
+			resize_mode: "Contain",
+			resize_fill_color: "#FFFFFF",
+			resize_flatten_rgb: true,
+			max_file_size_kb: 2048,
+			aspect_ratio_options: ["1:1", "4:3", "16:9", "3:2", "2:3", "Free"],
+			resize_mode_options: ["Contain", "Cover", "Stretch"],
 		};
 	},
 	watch: {
@@ -362,6 +447,16 @@ export default {
 			this.wm_tile_rotation = this.watermark_settings.tile_rotation != null ? this.watermark_settings.tile_rotation : -30;
 			this.wm_tile_spacing = this.watermark_settings.tile_spacing || 40;
 			this.load_watermark_image(this.watermark_settings.watermark_image);
+		}
+
+		// Output Shape: load settings (new 2026-04)
+		if (this.show_resize && this.resize_settings) {
+			this.resize_enabled = !!this.resize_settings.resize_enabled;
+			this.resize_aspect = this.resize_settings.resize_aspect || "1:1";
+			this.resize_mode = this.resize_settings.resize_mode || "Contain";
+			this.resize_fill_color = this.resize_settings.resize_fill_color || "#FFFFFF";
+			this.resize_flatten_rgb = !!this.resize_settings.resize_flatten_rgb;
+			this.max_file_size_kb = this.resize_settings.max_file_size_kb || 2048;
 		}
 
 		// Global listeners for watermark drag
@@ -619,15 +714,148 @@ export default {
 				}
 			}
 
-			const file_type = (this.bg_removed || this.wm_enabled) ? "image/png" : this.file.file_obj.type;
-			canvas.toBlob((blob) => {
+			// ── Output Shape step (new 2026-04) ──
+			// Apply aspect normalization + optional RGB flatten to a fresh
+			// canvas that mirrors the server-side PIL helper in
+			// item_image_batch.py::_apply_aspect_normalize. Happens AFTER the
+			// watermark composite (so comments / watermark stay on product
+			// content, not on Contain-padded fill strips).
+			let final_canvas = canvas;
+			if (this.show_resize && this.resize_enabled) {
+				final_canvas = this._apply_output_shape(canvas);
+			}
+
+			// Pick a type: flatten → JPEG (smaller, opaque); otherwise PNG
+			// when Remove BG or Watermark was applied (needs alpha or we
+			// have pixels that don't match the source type).
+			let file_type;
+			if (this.show_resize && this.resize_enabled && this.resize_flatten_rgb) {
+				file_type = "image/jpeg";
+			} else if (this.bg_removed || this.wm_enabled) {
+				file_type = "image/png";
+			} else {
+				file_type = this.file.file_obj.type;
+			}
+
+			final_canvas.toBlob((blob) => {
 				let name = this.file.name;
 				if (this.bg_removed) name = name.replace(/\.[^.]+$/, "_nobg.png");
 				if (this.wm_enabled) name = name.replace(/\.[^.]+$/, "_wm.png");
+				if (this.show_resize && this.resize_enabled) {
+					const ext = file_type === "image/jpeg" ? ".jpg" : ".png";
+					name = name.replace(/\.[^.]+$/, "_shape" + ext);
+				}
 				this.file.file_obj = new File([blob], name, { type: blob.type });
 				this.file.name = name;
 				this.$emit("toggle_image_cropper");
-			}, file_type);
+			}, file_type, file_type === "image/jpeg" ? 0.92 : undefined);
+		},
+
+		// Aspect-normalize a canvas via Canvas 2D. Mirrors the server-side
+		// _apply_aspect_normalize in item_image_batch.py so the baked file
+		// from a single-image upload and from a batch process look the same.
+		_apply_output_shape(src_canvas) {
+			const aspect_map = {
+				"1:1": [1, 1],
+				"4:3": [4, 3],
+				"16:9": [16, 9],
+				"3:2": [3, 2],
+				"2:3": [2, 3],
+			};
+
+			const aspect = this.resize_aspect;
+			const mode = this.resize_mode;
+			const sw = src_canvas.width;
+			const sh = src_canvas.height;
+
+			// Free or unknown → pass-through (optionally flatten)
+			if (aspect === "Free" || !(aspect in aspect_map)) {
+				return this._maybe_flatten(src_canvas, sw, sh, src_canvas);
+			}
+
+			const [tw, th] = aspect_map[aspect];
+			const src_ratio = sw / sh;
+			const tgt_ratio = tw / th;
+
+			if (Math.abs(src_ratio - tgt_ratio) < 1e-3) {
+				return this._maybe_flatten(src_canvas, sw, sh, src_canvas);
+			}
+
+			if (mode === "Stretch") {
+				let new_w, new_h;
+				if (src_ratio > tgt_ratio) {
+					new_w = sw;
+					new_h = Math.round(sw / tgt_ratio);
+				} else {
+					new_w = Math.round(sh * tgt_ratio);
+					new_h = sh;
+				}
+				const out = document.createElement("canvas");
+				out.width = new_w;
+				out.height = new_h;
+				out.getContext("2d").drawImage(src_canvas, 0, 0, new_w, new_h);
+				return this._maybe_flatten(out, new_w, new_h, out);
+			}
+
+			if (mode === "Cover") {
+				let new_w, new_h, off_x = 0, off_y = 0;
+				if (src_ratio > tgt_ratio) {
+					// Source wider — crop left/right
+					new_w = Math.round(sh * tgt_ratio);
+					new_h = sh;
+					off_x = Math.floor((sw - new_w) / 2);
+				} else {
+					// Source taller — crop top/bottom
+					new_w = sw;
+					new_h = Math.round(sw / tgt_ratio);
+					off_y = Math.floor((sh - new_h) / 2);
+				}
+				const out = document.createElement("canvas");
+				out.width = new_w;
+				out.height = new_h;
+				out.getContext("2d").drawImage(
+					src_canvas,
+					off_x, off_y, new_w, new_h,
+					0, 0, new_w, new_h,
+				);
+				return this._maybe_flatten(out, new_w, new_h, out);
+			}
+
+			// Contain: expand shorter axis, pad with fill color.
+			let canvas_w, canvas_h;
+			if (src_ratio > tgt_ratio) {
+				canvas_w = sw;
+				canvas_h = Math.round(sw / tgt_ratio);
+			} else {
+				canvas_w = Math.round(sh * tgt_ratio);
+				canvas_h = sh;
+			}
+			const out = document.createElement("canvas");
+			out.width = canvas_w;
+			out.height = canvas_h;
+			const ctx = out.getContext("2d");
+			// Fill the padding area first — transparent if flatten is off,
+			// or fill color if flatten is on so the composite is opaque.
+			if (this.resize_flatten_rgb) {
+				ctx.fillStyle = this.resize_fill_color || "#FFFFFF";
+				ctx.fillRect(0, 0, canvas_w, canvas_h);
+			}
+			const paste_x = Math.floor((canvas_w - sw) / 2);
+			const paste_y = Math.floor((canvas_h - sh) / 2);
+			ctx.drawImage(src_canvas, paste_x, paste_y);
+			return this._maybe_flatten(out, canvas_w, canvas_h, out);
+		},
+
+		_maybe_flatten(maybe_rgba_canvas, w, h, src_canvas) {
+			if (!this.resize_flatten_rgb) return maybe_rgba_canvas;
+			const out = document.createElement("canvas");
+			out.width = w;
+			out.height = h;
+			const ctx = out.getContext("2d");
+			ctx.fillStyle = this.resize_fill_color || "#FFFFFF";
+			ctx.fillRect(0, 0, w, h);
+			ctx.drawImage(src_canvas, 0, 0);
+			return out;
 		},
 
 		// ── Remove BG ──
@@ -1456,6 +1684,75 @@ img {
 		padding: 6px 10px;
 		font-size: 12px;
 	}
+}
+
+/* Output Shape section — lives in the adjustments panel. Same visual
+   language as the watermark tabs but with an extra `sublabel` column. */
+.adjustments-row-resize {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+.adjustments-field-hint {
+	font-weight: 400;
+	color: #7f8ea3;
+	font-size: 11px;
+	margin-left: 6px;
+}
+.resize-tabs-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+.resize-sublabel {
+	min-width: 52px;
+	font-size: 12px;
+	color: #606266;
+}
+.resize-misc-row {
+	display: flex;
+	gap: 14px;
+	align-items: center;
+	flex-wrap: wrap;
+	padding-left: 52px;
+}
+.resize-inline-field {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: #606266;
+}
+.resize-color {
+	width: 28px;
+	height: 24px;
+	padding: 0;
+	border: 1px solid #cbd5e1;
+	border-radius: 4px;
+	cursor: pointer;
+	background: transparent;
+}
+.resize-inline-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: #606266;
+	cursor: pointer;
+}
+.toggle-pill-sublabel {
+	font-size: 10px;
+	color: rgba(255, 255, 255, 0.85);
+	margin-left: 4px;
+	padding: 1px 4px;
+	background: rgba(0, 0, 0, 0.18);
+	border-radius: 6px;
+	font-weight: 500;
+}
+.segmented-tab.disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 </style>
 

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1179,6 +1179,17 @@ export default {
 					viewMode: 0,
 					zoomable: true,
 					scalable: false,
+					// Let the user zoom the image all the way down to a
+					// speck — we don't want CropperJS clamping the crop
+					// box back into the container when the image becomes
+					// smaller than the workspace. Crop rect is authored
+					// in natural-image coords and stays put regardless.
+					minContainerWidth: 0,
+					minContainerHeight: 0,
+					minCanvasWidth: 0,
+					minCanvasHeight: 0,
+					minCropBoxWidth: 0,
+					minCropBoxHeight: 0,
 					// Our zoom toolbar + on_wrapper_wheel handle wheel/pinch
 					// explicitly (via _zoom_preserving_crop), so CropperJS's
 					// own wheel/touch zoom is turned off to avoid two code
@@ -2375,7 +2386,12 @@ export default {
 			fn();
 			// The zoom action mutates container metrics synchronously;
 			// setData right after re-draws the crop box to match the
-			// saved natural rect at the new display scale.
+			// saved natural rect at the new display scale. Note:
+			// CropperJS still clamps the crop box to container bounds
+			// inside renderCropBox, so zooming out past the point where
+			// the saved rect would exceed the container will shrink it —
+			// that's a CropperJS constraint, not something we work
+			// around here.
 			this.cropper.setData(saved);
 		},
 		zoom_by(delta) {

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -129,18 +129,31 @@
 				</div>
 			</div>
 
-			<!-- Preview strip: live thumbnail, sized equal to the cropper
-			     above (flex:1 each in the left-col flex column). -->
+			<!-- Preview strip: dedicated row under the cropper. Label on top
+			     acts as the visual divider, thumbnail centered underneath
+			     at 1:1 height with the cropper above. Clicking the thumb
+			     opens an Element UI image-viewer (zoom + rotate) when the
+			     bundle is loaded; falls back to a plain canvas on forms
+			     where element-ui isn't registered. -->
 			<div class="cropper-preview-bar" v-if="any_feature_on">
-				<div class="cropper-preview-thumb">
-					<canvas ref="preview_canvas" class="resize-preview-canvas"></canvas>
+				<div class="cropper-preview-header">
+					<span class="cropper-preview-title">{{ __("Preview") }}</span>
+					<span class="cropper-preview-hint">{{ __("final output after Crop") }}</span>
 				</div>
-				<div class="cropper-preview-body">
-					<div class="cropper-preview-title">
-						{{ __("Preview") }}
-						<span class="cropper-preview-hint">{{ __("final output after Crop") }}</span>
+				<div class="cropper-preview-thumb" @click="_open_preview_viewer">
+					<canvas ref="preview_canvas" class="resize-preview-canvas"></canvas>
+					<div class="cropper-preview-zoom" :title="__('Click to enlarge')">
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><path d="M11 8v6"/><path d="M8 11h6"/></svg>
 					</div>
 				</div>
+			</div>
+			<!-- Lazy-mounted el-image viewer — only inserted when user clicks
+			     the zoom. We use the viewer widget directly (not wrapping
+			     <el-image>) so the cropper panel doesn't require
+			     element-ui to be loaded globally. -->
+			<div v-if="_preview_viewer_open && _preview_data_url" class="cropper-preview-viewer-host" @click.self="_preview_viewer_open = false">
+				<img :src="_preview_data_url" class="cropper-preview-viewer-img" @click.stop />
+				<button class="cropper-preview-viewer-close" @click="_preview_viewer_open = false" :title="__('Close')">×</button>
 			</div>
 
 		</div>
@@ -708,6 +721,12 @@ export default {
 			// Live preview (new 2026-04) — rerenders on any resize param
 			// change so the user sees exactly what Crop will produce.
 			preview_dims: null,
+			// Lightbox state for the preview thumbnail: click opens a
+			// full-size overlay (data URL snapshot of the current preview
+			// canvas) so the user can inspect the final baked output
+			// without leaving the cropper.
+			_preview_viewer_open: false,
+			_preview_data_url: null,
 			_preview_debounce: null,
 			// Comments (new 2026-04) — list of text overlays baked into
 			// the final Canvas composite. Overlay DOM boxes on top of the
@@ -906,6 +925,14 @@ export default {
 				this._modal_body_el = body;
 			}
 		});
+
+		// ESC key closes the preview lightbox overlay when open.
+		this._on_doc_keydown = (e) => {
+			if (e.key === "Escape" && this._preview_viewer_open) {
+				this._preview_viewer_open = false;
+			}
+		};
+		document.addEventListener("keydown", this._on_doc_keydown);
 	},
 	beforeDestroy() {
 		document.removeEventListener("mousemove", this._on_mousemove);
@@ -915,6 +942,7 @@ export default {
 		document.removeEventListener("touchmove", this._on_touchmove);
 		document.removeEventListener("touchend", this._on_touchend);
 		window.removeEventListener("resize", this._on_window_resize);
+		if (this._on_doc_keydown) document.removeEventListener("keydown", this._on_doc_keydown);
 		if (this._resize_raf) cancelAnimationFrame(this._resize_raf);
 		if (this._modal_body_el) {
 			this._modal_body_el.classList.remove("image-cropper-modal-body");
@@ -1733,6 +1761,44 @@ export default {
 		},
 
 		// ── Live preview (new 2026-04) ──
+		// Click handler on the preview thumb — snapshot the current
+		// preview canvas to a data URL and open an overlay with the
+		// full-resolution final output. We take the snapshot from the
+		// post-composite canvas rather than the live cropper so the
+		// user sees exactly what will be uploaded.
+		_open_preview_viewer() {
+			const canvas = this.$refs.preview_canvas;
+			if (!canvas) return;
+			try {
+				// Render a higher-resolution preview for the viewer by
+				// re-running the composite pipeline at the cropper's
+				// natural size, then serializing to a data URL.
+				const src = this.cropper ? this.cropper.getCroppedCanvas() : null;
+				if (src) {
+					const work = document.createElement("canvas");
+					work.width = src.width;
+					work.height = src.height;
+					const wctx = work.getContext("2d");
+					wctx.drawImage(src, 0, 0);
+					if (this.wm_enabled && this.wm_loaded && this.wm_img) {
+						this._composite_watermark_on_canvas(work, wctx);
+					}
+					if (this.show_comments && this.comments_enabled) {
+						this._composite_comments_on_canvas(work, wctx);
+					}
+					const final_canvas = (this.show_resize && this.resize_enabled)
+						? this._apply_output_shape(work)
+						: work;
+					this._preview_data_url = final_canvas.toDataURL("image/png");
+				} else {
+					this._preview_data_url = canvas.toDataURL("image/png");
+				}
+				this._preview_viewer_open = true;
+			} catch (e) {
+				console.error("preview viewer failed", e);
+			}
+		},
+
 		_schedule_preview_update() {
 			if (this._preview_debounce) clearTimeout(this._preview_debounce);
 			this._preview_debounce = setTimeout(() => {
@@ -2348,33 +2414,53 @@ img {
 }
 
 /* ── Preview bar below cropper ────────────────────────────────────
-   Sized equally with .cropper-image-wrapper (flex:1 each in the
-   left-col flex column) so "original working area" and "final
-   preview" are visually balanced — user can read the preview at
-   the same scale they're editing the source. On mobile the
-   preview stacks below at the same 1:1 ratio. */
+   Dedicated section below the cropper acting as a visual divider —
+   header on top, thumbnail centered. Sized equally with
+   .cropper-image-wrapper above (flex:1 each) so "edit area" and
+   "preview" mirror each other. */
 .cropper-preview-bar {
 	display: flex;
-	gap: 16px;
+	flex-direction: column;
+	gap: 10px;
 	padding: 12px 14px;
 	border: 1px solid var(--border-color);
 	border-radius: 8px;
 	background: var(--fg-color, white);
-	align-items: center;
+	align-items: stretch;
 	flex: 1 1 0;
 	min-height: 0;
 	overflow: hidden;
 }
-.cropper-preview-thumb {
-	flex-shrink: 0;
-	height: 100%;
-	aspect-ratio: 1 / 1;   /* keep the thumb square even as height flexes */
+.cropper-preview-header {
 	display: flex;
-	flex-direction: column;
+	align-items: baseline;
+	gap: 8px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid var(--border-color);
+	flex-shrink: 0;
+}
+.cropper-preview-title {
+	font-weight: 600;
+	font-size: 15px;
+	color: #303133;
+}
+.cropper-preview-hint {
+	font-weight: 400;
+	font-size: 13px;
+	color: #94a3b8;
+}
+.cropper-preview-thumb {
+	position: relative;
+	flex: 1 1 auto;
+	min-height: 0;
+	display: flex;
 	align-items: center;
 	justify-content: center;
-	min-height: 0;
+	cursor: zoom-in;
+	transition: opacity 0.15s ease;
 }
+.cropper-preview-thumb:hover { opacity: 0.92; }
+.cropper-preview-thumb:hover .cropper-preview-zoom { opacity: 1; }
 .cropper-preview-thumb canvas {
 	max-width: 100%;
 	max-height: 100%;
@@ -2392,28 +2478,70 @@ img {
 	border-radius: 6px;
 	display: block;
 }
-.cropper-preview-dims {
-	margin-top: 6px;
-	font-size: 12px;
-	color: #64748b;
-	text-align: center;
-	font-variant-numeric: tabular-nums;
-	font-weight: 500;
+.cropper-preview-zoom {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	width: 28px;
+	height: 28px;
+	border-radius: 50%;
+	background: rgba(15, 23, 42, 0.72);
+	color: #fff;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 0;
+	transition: opacity 0.15s ease;
+	pointer-events: none;   /* visual hint only, parent owns the click */
 }
-.cropper-preview-body {
-	flex: 1;
-	min-width: 0;
+
+/* Lightbox overlay shown when user clicks the preview thumb. */
+.cropper-preview-viewer-host {
+	position: fixed;
+	inset: 0;
+	background: rgba(15, 23, 42, 0.82);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 2050;  /* above Bootstrap modal (1055) */
+	padding: 40px;
+	cursor: zoom-out;
 }
-.cropper-preview-title {
-	font-weight: 600;
-	font-size: 15px;
-	color: #303133;
+.cropper-preview-viewer-img {
+	max-width: 100%;
+	max-height: 100%;
+	object-fit: contain;
+	border-radius: 6px;
+	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+	background: #fff;
+	background-image:
+		linear-gradient(45deg, #f0f0f0 25%, transparent 25%),
+		linear-gradient(-45deg, #f0f0f0 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #f0f0f0 75%),
+		linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
+	background-size: 16px 16px;
+	cursor: default;
 }
-.cropper-preview-hint {
-	margin-left: 6px;
-	font-weight: 400;
-	font-size: 13px;
-	color: #94a3b8;
+.cropper-preview-viewer-close {
+	position: absolute;
+	top: 20px;
+	right: 24px;
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	border: none;
+	background: rgba(255, 255, 255, 0.15);
+	color: #fff;
+	font-size: 28px;
+	line-height: 1;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: background 0.15s ease;
+}
+.cropper-preview-viewer-close:hover {
+	background: rgba(255, 255, 255, 0.28);
 }
 .cropper-preview-chips {
 	margin-top: 6px;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -129,30 +129,16 @@
 				</div>
 			</div>
 
-			<!-- Preview strip: live thumbnail + chip summary of what's on -->
+			<!-- Preview strip: live thumbnail, sized equal to the cropper
+			     above (flex:1 each in the left-col flex column). -->
 			<div class="cropper-preview-bar" v-if="any_feature_on">
 				<div class="cropper-preview-thumb">
 					<canvas ref="preview_canvas" class="resize-preview-canvas"></canvas>
-					<div v-if="preview_dims" class="cropper-preview-dims">
-						{{ preview_dims.w }} × {{ preview_dims.h }} {{ preview_format_label }}
-					</div>
 				</div>
 				<div class="cropper-preview-body">
 					<div class="cropper-preview-title">
 						{{ __("Preview") }}
 						<span class="cropper-preview-hint">{{ __("final output after Crop") }}</span>
-					</div>
-					<div class="cropper-preview-chips">
-						<span v-if="show_remove_bg && bg_removed" class="cropper-preview-chip">{{ __("Remove BG") }}</span>
-						<span v-if="show_watermark && wm_enabled" class="cropper-preview-chip">
-							{{ __("Watermark") }} · {{ wm_mode === "Tiled" ? __("Tiled") : __("Corner") }}
-						</span>
-						<span v-if="show_comments && comments_enabled && comment_boxes.length" class="cropper-preview-chip">
-							{{ __("Comments") }} · {{ comment_boxes.length }}
-						</span>
-						<span v-if="show_resize && resize_enabled" class="cropper-preview-chip">
-							{{ __("Canvas") }} · {{ resize_aspect }}
-						</span>
 					</div>
 				</div>
 			</div>
@@ -888,6 +874,9 @@ export default {
 				if (this.wm_enabled && this.wm_loaded) {
 					this.wm_resize_canvas();
 				}
+				// Preview thumb's container changes size with the modal,
+				// so re-render the preview at the new resolution.
+				this._schedule_preview_update();
 			});
 		};
 		window.addEventListener("resize", this._on_window_resize);
@@ -1788,9 +1777,16 @@ export default {
 				? this._apply_output_shape(work)
 				: work;
 
-			// Compute display box: letterbox into 280×280 preserving aspect
-			// (matches the 140px CSS-displayed canvas at 2× device pixel ratio).
-			const MAX = 280;
+			// Compute display box from the preview thumb's actual rendered
+			// size (the thumb is sized by CSS flex:1 matching the cropper
+			// height, so the preview scales with the modal height). Fall
+			// back to 280 on mount before layout has settled.
+			const thumb = preview_canvas.parentElement;
+			const maxAvail = thumb
+				? Math.max(120, Math.min(thumb.clientWidth || 280, thumb.clientHeight || 280))
+				: 280;
+			const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
+			const MAX = Math.round(maxAvail * dpr);
 			const ratio = final_canvas.width / final_canvas.height;
 			let disp_w, disp_h;
 			if (ratio >= 1) {
@@ -1802,6 +1798,9 @@ export default {
 			}
 			preview_canvas.width = disp_w;
 			preview_canvas.height = disp_h;
+			// CSS size (what the user sees) is disp_* / dpr.
+			preview_canvas.style.width = Math.round(disp_w / dpr) + "px";
+			preview_canvas.style.height = Math.round(disp_h / dpr) + "px";
 			const pctx = preview_canvas.getContext("2d");
 			pctx.clearRect(0, 0, disp_w, disp_h);
 			pctx.drawImage(final_canvas, 0, 0, disp_w, disp_h);
@@ -2304,6 +2303,7 @@ export default {
 	flex-direction: column;
 	min-width: 0;
 	min-height: 0;
+	gap: 10px;
 }
 .cropper-right-col {
 	display: flex;
@@ -2347,24 +2347,39 @@ img {
 	max-height: min(600px, calc(100vh - 320px));
 }
 
-/* ── Preview bar below cropper ── */
+/* ── Preview bar below cropper ────────────────────────────────────
+   Sized equally with .cropper-image-wrapper (flex:1 each in the
+   left-col flex column) so "original working area" and "final
+   preview" are visually balanced — user can read the preview at
+   the same scale they're editing the source. On mobile the
+   preview stacks below at the same 1:1 ratio. */
 .cropper-preview-bar {
 	display: flex;
 	gap: 16px;
 	padding: 12px 14px;
-	margin-top: 10px;
 	border: 1px solid var(--border-color);
 	border-radius: 8px;
 	background: var(--fg-color, white);
 	align-items: center;
-	flex-shrink: 0;
+	flex: 1 1 0;
+	min-height: 0;
+	overflow: hidden;
 }
 .cropper-preview-thumb {
 	flex-shrink: 0;
+	height: 100%;
+	aspect-ratio: 1 / 1;   /* keep the thumb square even as height flexes */
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	min-height: 0;
 }
 .cropper-preview-thumb canvas {
-	width: 140px;
-	height: 140px;
+	max-width: 100%;
+	max-height: 100%;
+	width: auto;
+	height: auto;
 	border: 1px solid var(--border-color);
 	background: #ffffff;
 	background-image:
@@ -2598,10 +2613,32 @@ img {
 	font-weight: 500;
 }
 
-/* ── Mobile: stack left + right columns ── */
+/* ── Mobile: stack left + right columns ──
+   Grid collapses to one column and rows auto-stretch. The cropper
+   wrapper and preview bar keep the 1:1 flex ratio inside left-col,
+   and the right panel stacks below at its natural height. The
+   whole page is vertically scrollable so on phones the user sees
+   cropper → preview → params → Crop button by scrolling. */
 @media (max-width: 900px) {
 	.cropper-grid {
 		grid-template-columns: 1fr;
+		grid-template-rows: auto auto auto;
+		height: auto;
+	}
+	.cropper-left-col {
+		/* On mobile, cropper + preview each take 40vh so both are visible
+		   at once without forcing a huge viewport. Together with the
+		   right-col and action bar they fit a normal phone viewport. */
+		min-height: 80vh;
+	}
+	.cropper-image-wrapper,
+	.cropper-preview-bar {
+		flex: 1 1 40vh;
+		min-height: 40vh;
+	}
+	.cropper-right-col {
+		max-height: none;
+		overflow: visible;
 	}
 	.cropper-feature-tabs {
 		grid-template-columns: repeat(4, 1fr);
@@ -2612,6 +2649,17 @@ img {
 	.wm-slider-row .wm-slider-label { width: 82px; font-size: 13px; }
 	.wm-slider-row .wm-slider-value { width: 44px; font-size: 12px; }
 	.segmented-tab { padding: 7px 12px; font-size: 13px; }
+	.cropper-preview-thumb canvas { max-width: 100%; max-height: 100%; }
+}
+@media (max-width: 480px) {
+	/* Very small phones — shrink each row further so all 3 sections
+	   still fit in a single swipe. */
+	.cropper-left-col { min-height: 72vh; }
+	.cropper-image-wrapper,
+	.cropper-preview-bar {
+		flex: 1 1 36vh;
+		min-height: 36vh;
+	}
 }
 
 /* ── Unified Image Adjustments panel ──
@@ -2738,9 +2786,8 @@ img {
 
 .cropper-image-wrapper {
 	position: relative;
-	flex: 1 1 auto;
+	flex: 1 1 0;   /* equal share with .cropper-preview-bar below (flex:1 each = 1:1) */
 	min-height: 0;
-	max-height: 60vh;   /* leave room for preview + bottom action bar */
 	overflow: hidden;
 }
 .cropper-image-wrapper img {

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -1503,12 +1503,21 @@ export default {
 			};
 		},
 		comment_text_style(box) {
-			const cd = this.canvas_data;
-			// Compute px font size from the displayed image height, not
-			// the natural size (so on-screen text matches what user sees
-			// in the preview).
-			const displayH = (cd && cd.height) ? cd.height : 200;
-			const fontPx = Math.max(6, Math.round(displayH * (box.font_size_pct || 5.0) / 100));
+			// Font size basis = CROP display height × pct, matching the
+			// server-side bake (which uses the cropped image's height).
+			// Using the full image's display height would make overlay
+			// text appear smaller than the preview whenever the crop
+			// rect is shorter than the whole image.
+			let basisPx = 200;
+			try {
+				if (this.cropper) {
+					const cropDisplay = this.cropper.getCropBoxData();
+					if (cropDisplay && cropDisplay.height > 0) {
+						basisPx = cropDisplay.height;
+					}
+				}
+			} catch (e) { /* pre-ready */ }
+			const fontPx = Math.max(6, Math.round(basisPx * (box.font_size_pct || 5.0) / 100));
 			return {
 				fontFamily: `"${box.font_family || "Arial"}", sans-serif`,
 				fontSize: fontPx + "px",
@@ -2045,9 +2054,12 @@ export default {
 			// is explicitly on — that's the one case where transparency
 			// is baked to a solid color and JPEG's compression wins.
 			try {
-				const flatten = this.show_resize && this.resize_enabled && this.resize_flatten_rgb;
-				const fmt = flatten ? "image/jpeg" : "image/png";
-				this.preview_data_url = final_canvas.toDataURL(fmt, 0.88);
+				// Preview is always PNG — lossless colour, so the thumb
+				// matches the workspace exactly. JPEG branch was an
+				// optimisation for flattened Canvas output but it shifted
+				// colours relative to the cropper, making the preview
+				// look "different" even when nothing actually changed.
+				this.preview_data_url = final_canvas.toDataURL("image/png");
 			} catch (e) {
 				// toDataURL can throw on huge canvases; fall back to null
 				this.preview_data_url = null;
@@ -3957,18 +3969,12 @@ img {
 	z-index: 2049 !important;
 }
 .el-image-viewer__canvas .el-image-viewer__img {
-	/* Checkerboard baked into the img element so PNG transparency is
-	   visible in the lightbox. The img has its own pixel data on top,
-	   so the checker only shows through transparent regions — same
-	   pattern Photoshop / Figma / Photopea use for transparent view. */
-	background-color: #ffffff;
-	background-image:
-		linear-gradient(45deg, #d1d5db 25%, transparent 25%),
-		linear-gradient(-45deg, #d1d5db 25%, transparent 25%),
-		linear-gradient(45deg, transparent 75%, #d1d5db 75%),
-		linear-gradient(-45deg, transparent 75%, #d1d5db 75%);
-	background-size: 20px 20px;
-	background-position: 0 0, 0 10px, 10px -10px, -10px 0;
+	/* Match the cropper workspace backdrop (#2c2c2c) so what the user
+	   sees in the thumb/lightbox is identical in colour to the cropper
+	   stage. No white fill and no checkerboard — the workspace itself
+	   doesn't show one either; the dark backdrop reads as "this area
+	   is transparent" by convention. */
+	background-color: #2c2c2c;
 	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
 	border-radius: 4px;
 }

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -65,6 +65,20 @@
 					</div>
 				</div>
 
+				<!-- Zoom group — viewMode:0 lets the crop box extend past the
+				     image, so users need explicit zoom controls to zoom out
+				     and see the working area around the picture. Wheel +
+				     pinch are also active on the stage. -->
+				<div class="cropper-toolbar-group">
+					<span class="cropper-toolbar-label">{{ __("Zoom") }}:</span>
+					<div class="btn-group btn-group-sm">
+						<button type="button" class="btn btn-default btn-sm" :title="__('Zoom out')" @click="zoom_by(-0.1)">−</button>
+						<button type="button" class="btn btn-default btn-sm" :title="__('Fit to workspace')" @click="zoom_fit">{{ __("Fit") }}</button>
+						<button type="button" class="btn btn-default btn-sm" :title="__('Actual size 1:1')" @click="zoom_actual">1:1</button>
+						<button type="button" class="btn btn-default btn-sm" :title="__('Zoom in')" @click="zoom_by(0.1)">+</button>
+					</div>
+				</div>
+
 				<!-- Preview block inline in the toolbar, right-aligned via
 				     margin-left: auto so the full toolbar height stays
 				     compact (~50px, determined by the taller segmented
@@ -115,7 +129,6 @@
 						'comment-mode': interaction_mode === 'comment',
 						'bg-processing': bg_processing,
 					}"
-					:style="wrapper_aspect_style"
 					@mousedown="on_wrapper_mousedown"
 					@wheel.prevent="on_wrapper_wheel"
 					@touchstart="on_wrapper_touchstart"
@@ -777,11 +790,6 @@ export default {
 			// Canvas data cache (image display rect in cropper wrapper)
 			// updated on cropper ready + crop event for overlay positioning.
 			_canvas_data: null,
-			// Natural aspect ratio (w/h) of the source image, driven by the
-			// <img @load> handler. Used to size .cropper-image-wrapper to
-			// exactly the picture's contain-bbox so the crop box can't be
-			// dragged into empty dead-zones.
-			natural_aspect_ratio: null,
 			comment_font_families: [
 				"Arial", "Helvetica", "Times New Roman",
 				"Courier New", "Georgia", "Verdana",
@@ -814,10 +822,11 @@ export default {
 			this._schedule_preview_update();
 			this.$emit("resize_enabled_changed", !!v);
 		},
-		comments_enabled(v) {
-			this._schedule_preview_update();
-			this.$emit("comments_enabled_changed", !!v);
-		},
+		// Merged with the duplicate comments_enabled() below to preserve
+		// the $emit (Vue keeps only the last-declared watcher of the same
+		// key). Without this, FileUploader.comments_enabled_default never
+		// re-syncs with the cropper's toggle.
+
 		resize_aspect() { this._schedule_preview_update(); },
 		resize_mode() { this._schedule_preview_update(); },
 		resize_fill_color() { this._schedule_preview_update(); },
@@ -859,7 +868,10 @@ export default {
 				this.$nextTick(() => this._schedule_preview_update());
 			}
 		},
-		comments_enabled() { this._schedule_preview_update(); },
+		comments_enabled(v) {
+			this._schedule_preview_update();
+			this.$emit("comments_enabled_changed", !!v);
+		},
 		comment_boxes: {
 			handler() { this._schedule_preview_update(); },
 			deep: true,
@@ -1071,15 +1083,6 @@ export default {
 		}
 	},
 	computed: {
-		// CSS binding that sizes .cropper-image-wrapper to the source image's
-		// natural aspect ratio. Combined with max-width/max-height:100% in
-		// the stylesheet this gives a perfect contain-fit inside the stage,
-		// so the wrapper box edge == the image edge (no grey dead-zone the
-		// crop box can't reach).
-		wrapper_aspect_style() {
-			if (!this.natural_aspect_ratio) return {};
-			return { aspectRatio: String(this.natural_aspect_ratio) };
-		},
 		aspect_ratio_buttons() {
 			return [
 				{ label: __("1:1"), value: 1 },
@@ -1157,15 +1160,10 @@ export default {
 		},
 	},
 	methods: {
-		// Capture the source image's natural aspect ratio so the wrapper
-		// box (which CropperJS mounts on) sizes exactly to the image's
-		// contain-fit rect. Runs before init_cropper because CropperJS
-		// reads the container size once on mount.
-		on_image_load(e) {
-			const img = e && e.target;
-			if (img && img.naturalWidth && img.naturalHeight) {
-				this.natural_aspect_ratio = img.naturalWidth / img.naturalHeight;
-			}
+		on_image_load() {
+			// Kept as a no-op template handler hook in case downstream
+			// subclasses want to observe natural size. CropperJS re-reads
+			// naturalWidth/Height on its own ready callback.
 		},
 		// ── Image loading ──
 		load_image(file) {
@@ -1182,24 +1180,21 @@ export default {
 			if (this.cropper) this.cropper.destroy();
 			let crop_box = this.file.crop_box_data;
 			this.image = this.$refs.image;
-			// Ensure the wrapper aspect ratio is set before CropperJS mounts —
-			// CropperJS reads the container size once, so a stale wrapper box
-			// leaves dead space around the picture. Vue's @load usually fires
-			// this, but for fast data URL decodes the browser may skip the
-			// load event if the image is already complete in cache.
-			if (
-				this.image &&
-				this.image.naturalWidth &&
-				this.image.naturalHeight
-			) {
-				this.natural_aspect_ratio =
-					this.image.naturalWidth / this.image.naturalHeight;
-			}
 			this.image.onload = () => {
 				this.cropper = new Cropper(this.image, {
-					zoomable: false,
+					// viewMode 0: crop box may extend beyond the image edges —
+					// the standard Photoshop/Photopea/Lightroom workspace where
+					// the image floats in a larger canvas. Needed for Remove BG
+					// + padding (auto-crop can expand past image bounds) and for
+					// "Save with Canvas" that deliberately adds transparent
+					// margins around the product.
+					viewMode: 0,
+					zoomable: true,
 					scalable: false,
-					viewMode: 1,
+					zoomOnTouch: true,
+					zoomOnWheel: true,
+					wheelZoomRatio: 0.1,
+					autoCropArea: 1,
 					data: crop_box,
 					aspectRatio: this.aspect_ratio,
 					ready: () => {
@@ -1307,67 +1302,12 @@ export default {
 		// ── Crop ──
 		crop_image() {
 			const crop_data = this.cropper.getData();
-			const image_data = this.cropper.getImageData();
 			this.file.crop_box_data = crop_data;
 			const canvas = this.cropper.getCroppedCanvas();
 
 			if (this.wm_enabled && this.wm_loaded && this.wm_img) {
 				const ctx = canvas.getContext("2d");
-				const cw = canvas.width;
-				const ch = canvas.height;
-				const full_w = image_data.naturalWidth;
-				const full_h = image_data.naturalHeight;
-				const crop_x = crop_data.x;
-				const crop_y = crop_data.y;
-				const crop_w = crop_data.width;
-				const crop_h = crop_data.height;
-				const scale_x = cw / crop_w;
-				const scale_y = ch / crop_h;
-
-				if (this.wm_mode === "Tiled") {
-					// Tiled watermark on cropped canvas
-					const tile_w = (this.wm_tile_size / 100) * full_w * scale_x;
-					const tile_h = tile_w * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
-					const spacing_x = (this.wm_tile_spacing / 100) * full_w * scale_x;
-					const spacing_y = (this.wm_tile_spacing / 100) * full_h * scale_y;
-					const step_x = tile_w + spacing_x;
-					const step_y = tile_h + spacing_y;
-					const angle = (this.wm_tile_rotation * Math.PI) / 180;
-
-					ctx.save();
-					ctx.globalAlpha = this.wm_tile_opacity / 100;
-					ctx.translate(cw / 2, ch / 2);
-					ctx.rotate(angle);
-					const diag = Math.sqrt(cw * cw + ch * ch);
-					for (let y = -diag; y < diag; y += step_y) {
-						for (let x = -diag; x < diag; x += step_x) {
-							ctx.drawImage(this.wm_img, x, y, tile_w, tile_h);
-						}
-					}
-					ctx.restore();
-				} else {
-					// Corner watermark
-					const wm_center_x = (this.wm_pos_x / 100) * full_w;
-					const wm_center_y = (this.wm_pos_y / 100) * full_h;
-					const wm_w_full = (this.wm_size / 100) * full_w;
-					const wm_h_full = wm_w_full * (this.wm_img.naturalHeight / this.wm_img.naturalWidth);
-					const draw_x = (wm_center_x - wm_w_full / 2 - crop_x) * scale_x;
-					const draw_y = (wm_center_y - wm_h_full / 2 - crop_y) * scale_y;
-					const draw_w = wm_w_full * scale_x;
-					const draw_h = wm_h_full * scale_y;
-					const rot = (this.wm_corner_rotation || 0) * Math.PI / 180;
-					ctx.save();
-					ctx.globalAlpha = this.wm_opacity / 100;
-					if (rot) {
-						const cx = draw_x + draw_w / 2;
-						const cy = draw_y + draw_h / 2;
-						ctx.translate(cx, cy);
-						ctx.rotate(rot);
-						ctx.translate(-cx, -cy);
-					}
-					ctx.drawImage(this.wm_img, draw_x, draw_y, draw_w, draw_h);
-					ctx.restore();
-				}
+				this._composite_watermark_on_canvas(canvas, ctx);
 			}
 
 			// ── Comments step (new 2026-04) ──
@@ -1775,15 +1715,27 @@ export default {
 		// whitelisted endpoint. Matches the Save as Default button
 		// on Remove BG / Watermark / Canvas tabs.
 		_save_comments_panel() {
+			const presets_snapshot = (this.comment_boxes || []).map((b) => ({ ...b }));
+			const enabled_snapshot = this.comments_enabled ? 1 : 0;
 			frappe.call({
 				method: "next.next.doctype.image_processing_settings.image_processing_settings.update_comment_presets",
 				args: {
-					presets_json: JSON.stringify(this.comment_boxes || []),
-					enabled: this.comments_enabled ? 1 : 0,
+					presets_json: JSON.stringify(presets_snapshot),
+					enabled: enabled_snapshot,
 				},
 				callback: () => {
+					// Refresh the client-side settings cache used by item.js
+					// so the next time the uploader opens, Comments comes up
+					// with the new enabled state + preset list. Without this,
+					// the cache keeps serving the pre-save snapshot and the
+					// user sees the toggle revert on reopen — especially
+					// confusing when the preset list is empty but enabled.
+					if (frappe._image_processing_settings_cache) {
+						frappe._image_processing_settings_cache.default_comments_enabled = !!enabled_snapshot;
+						frappe._image_processing_settings_cache.comment_presets = presets_snapshot;
+					}
 					frappe.show_alert({
-						message: __("Saved {0} comments as default", [this.comment_boxes.length]),
+						message: __("Saved {0} comments as default", [presets_snapshot.length]),
 						indicator: "green",
 					});
 				},
@@ -2314,6 +2266,23 @@ export default {
 			const cd = this.cropper.getCanvasData();
 			const r = this.wm_get_rect_in_container(cd);
 			return mx >= r.x && mx <= r.x + r.w && my >= r.y && my <= r.y + r.h;
+		},
+
+		// ── Zoom controls (viewMode:0 workspace) ──
+		// cropper.zoom(ratio) is relative (delta); zoomTo(absolute) sets
+		// display/natural. "Fit" recenters + fits the image into the
+		// container via cropper.reset(), matching the initial mount state.
+		zoom_by(delta) {
+			if (!this.cropper) return;
+			this.cropper.zoom(delta);
+		},
+		zoom_fit() {
+			if (!this.cropper) return;
+			this.cropper.reset();
+		},
+		zoom_actual() {
+			if (!this.cropper) return;
+			this.cropper.zoomTo(1);
 		},
 
 		set_mode(mode) {
@@ -3015,13 +2984,12 @@ img {
 }
 
 /* Two-level cropper layout.
-   .cropper-image-stage — the dark flex-filling backdrop (shows around
-     the picture when the workspace aspect differs from the image).
-   .cropper-image-wrapper — sized to the image's natural aspect ratio
-     via :style="wrapper_aspect_style" so its bounding rect matches the
-     actual image display rect. CropperJS mounts on this, so the crop
-     box's bounds equal the image edges — no grey dead-zone the box
-     can't reach. Matches Photoshop / Figma / Lightroom behaviour. */
+   .cropper-image-stage — dark flex-filling backdrop (the "artboard").
+   .cropper-image-wrapper — fills the stage; CropperJS mounts on the
+     <img> inside and takes over rendering (image centered, checkerboard
+     background showing through transparent pixels, zoomable workspace).
+     With viewMode:0 the crop box can extend beyond the image into the
+     working area — matching Photoshop / Photopea / Lightroom behaviour. */
 .cropper-image-stage {
 	position: relative;
 	flex: 1 1 auto;
@@ -3037,30 +3005,12 @@ img {
 }
 .cropper-image-wrapper {
 	position: relative;
-	max-width: 100%;
-	max-height: 100%;
-	/* aspect-ratio is applied inline via wrapper_aspect_style. Until the
-	   <img @load> handler fires (first paint / SSR-like state) fall back
-	   to 1 so the empty box has a sane shape. */
-	aspect-ratio: 1;
 	width: 100%;
 	height: 100%;
+	min-width: 0;
+	min-height: 0;
 	overflow: hidden;
 	border-radius: 4px;
-	/* Subtle checkerboard shows through transparent PNGs so the user can
-	   see "this area is transparent" instead of guessing from grey. */
-	background-color: #fdfdfd;
-	background-image:
-		linear-gradient(45deg, #e9edf2 25%, transparent 25%),
-		linear-gradient(-45deg, #e9edf2 25%, transparent 25%),
-		linear-gradient(45deg, transparent 75%, #e9edf2 75%),
-		linear-gradient(-45deg, transparent 75%, #e9edf2 75%);
-	background-size: 16px 16px;
-	background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
-	/* Distinct border so the image's edge is visually obvious — the
-	   crop box stops exactly here. */
-	box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.18),
-		0 4px 18px rgba(0, 0, 0, 0.35);
 }
 .cropper-image-wrapper img {
 	max-width: 100%;

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -170,9 +170,9 @@
 					@click="active_tab = 'remove_bg'"
 				>
 					<span class="cropper-feature-tab-label">{{ __("Remove BG") }}</span>
-					<span class="cropper-feature-tab-state" :class="bg_removed ? 'on' : 'off'">
+					<span class="cropper-feature-tab-state" :class="(bg_removed || bg_processing) ? 'on' : 'off'">
 						<span class="cropper-feature-tab-dot"></span>
-						{{ bg_removed ? __("on") : __("off") }}
+						{{ bg_processing ? __("…") : (bg_removed ? __("on") : __("off")) }}
 					</span>
 				</button>
 				<button
@@ -1788,8 +1788,9 @@ export default {
 				? this._apply_output_shape(work)
 				: work;
 
-			// Compute display box: letterbox into 200×200 preserving aspect
-			const MAX = 200;
+			// Compute display box: letterbox into 280×280 preserving aspect
+			// (matches the 140px CSS-displayed canvas at 2× device pixel ratio).
+			const MAX = 280;
 			const ratio = final_canvas.width / final_canvas.height;
 			let disp_w, disp_h;
 			if (ratio >= 1) {
@@ -2289,10 +2290,11 @@ export default {
 .cropper-grid {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) 420px;
-	grid-template-rows: 1fr auto;
+	grid-template-rows: minmax(0, 1fr) auto;
 	gap: 20px;
 	align-items: stretch;
 	min-height: 0;
+	height: 100%;
 }
 .cropper-grid .image-cropper-actions-bottom {
 	grid-column: 1 / -1;
@@ -2309,6 +2311,8 @@ export default {
 	gap: 10px;
 	min-width: 0;
 	min-height: 0;
+	max-height: 100%;
+	overflow-y: auto;
 }
 
 /* ── Top toolbar (drag mode + crop ratio, above the cropper) ── */
@@ -2347,19 +2351,20 @@ img {
 .cropper-preview-bar {
 	display: flex;
 	gap: 16px;
-	padding: 10px 14px;
+	padding: 12px 14px;
 	margin-top: 10px;
 	border: 1px solid var(--border-color);
 	border-radius: 8px;
 	background: var(--fg-color, white);
 	align-items: center;
+	flex-shrink: 0;
 }
 .cropper-preview-thumb {
 	flex-shrink: 0;
 }
 .cropper-preview-thumb canvas {
-	width: 72px;
-	height: 72px;
+	width: 140px;
+	height: 140px;
 	border: 1px solid var(--border-color);
 	background: #ffffff;
 	background-image:
@@ -2369,15 +2374,16 @@ img {
 		linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
 	background-size: 12px 12px;
 	background-position: 0 0, 0 6px, 6px -6px, -6px 0;
-	border-radius: 4px;
+	border-radius: 6px;
 	display: block;
 }
 .cropper-preview-dims {
-	margin-top: 4px;
-	font-size: 10px;
+	margin-top: 6px;
+	font-size: 12px;
 	color: #64748b;
 	text-align: center;
 	font-variant-numeric: tabular-nums;
+	font-weight: 500;
 }
 .cropper-preview-body {
 	flex: 1;
@@ -2385,13 +2391,13 @@ img {
 }
 .cropper-preview-title {
 	font-weight: 600;
-	font-size: 13px;
+	font-size: 15px;
 	color: #303133;
 }
 .cropper-preview-hint {
 	margin-left: 6px;
 	font-weight: 400;
-	font-size: 11px;
+	font-size: 13px;
 	color: #94a3b8;
 }
 .cropper-preview-chips {
@@ -2732,6 +2738,15 @@ img {
 
 .cropper-image-wrapper {
 	position: relative;
+	flex: 1 1 auto;
+	min-height: 0;
+	max-height: 60vh;   /* leave room for preview + bottom action bar */
+	overflow: hidden;
+}
+.cropper-image-wrapper img {
+	max-width: 100%;
+	max-height: 100%;
+	display: block;
 }
 
 .cropper-image-wrapper.wm-mode {

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -24,10 +24,11 @@ export default class FileUploader {
 		remove_bg_disabled_hint,
 		remove_bg_disabled_link,
 		remove_bg_padding_pct,
+		default_crop_aspect,
+		default_solid_background,
+		default_background_color,
 		show_watermark,
 		watermark_settings,
-		show_resize,
-		resize_settings,
 		show_comments,
 		comment_defaults,
 		comment_presets,
@@ -39,8 +40,6 @@ export default class FileUploader {
 		this.remove_bg_padding_pct = remove_bg_padding_pct;
 		this.show_watermark = show_watermark;
 		this.watermark_settings = watermark_settings;
-		this.show_resize = show_resize;
-		this.resize_settings = resize_settings;
 		this.show_comments = show_comments;
 		this.comment_defaults = comment_defaults;
 		this.comment_presets = comment_presets;
@@ -74,10 +73,11 @@ export default class FileUploader {
 						remove_bg_default,
 						remove_bg_disabled_hint,
 						remove_bg_padding_pct,
+						default_crop_aspect,
+						default_solid_background,
+						default_background_color,
 						show_watermark,
 						watermark_settings,
-						show_resize,
-						resize_settings,
 						show_comments,
 						comment_defaults,
 						comment_presets,

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -140,51 +140,11 @@ export default class FileUploader {
 			this.uploader.add_files(files);
 		}
 
-		// Add footer toggles after uploader is ready. Order matches the
-		// tabs inside the cropper (Remove BG → Watermark → Comments →
-		// Canvas) so the user sees the same 4 features in the same order
-		// on both the file-picker page and the cropper page.
-		if (this.dialog && this.show_remove_bg) {
-			this.add_footer_toggle(
-				"remove_bg",
-				__("Remove Background"),
-				"remove_bg_checked",
-				!this.remove_bg_disabled_hint,
-				this.remove_bg_disabled_hint || null,
-				this.remove_bg_disabled_link || null,
-			);
-		}
-		if (this.dialog && this.show_watermark) {
-			const has_config = this.watermark_settings && this.watermark_settings.watermark_image;
-			this.add_footer_toggle(
-				"watermark",
-				__("Watermark"),
-				"wm_enabled",
-				has_config && this.watermark_settings.enabled ? true : false,
-				has_config ? null : __("Click to configure watermark"),
-				has_config ? null : "/app/watermark-settings",
-			);
-		}
-		if (this.dialog && this.show_comments) {
-			this.add_footer_toggle(
-				"comments",
-				__("Comments"),
-				"comments_enabled_default",
-				!!(this.comment_defaults && this.comment_defaults.enabled),
-				null,
-				null,
-			);
-		}
-		if (this.dialog && this.show_resize) {
-			this.add_footer_toggle(
-				"canvas",
-				__("Canvas"),
-				"resize_enabled_default",
-				!!(this.resize_settings && this.resize_settings.resize_enabled),
-				null,
-				null,
-			);
-		}
+		// Note: the footer-toggle pills (Remove BG / Watermark / Comments /
+		// Canvas) have been removed. They are now rendered as tabs + toggle
+		// switches inside the uploader body's right-side panel, which keeps
+		// one source of truth for feature state across all 3 steps (file
+		// picker, cropper, post-crop list).
 	}
 
 	upload_files() {

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -140,7 +140,10 @@ export default class FileUploader {
 			this.uploader.add_files(files);
 		}
 
-		// Add footer toggles after uploader is ready
+		// Add footer toggles after uploader is ready. Order matches the
+		// tabs inside the cropper (Remove BG → Watermark → Comments →
+		// Canvas) so the user sees the same 4 features in the same order
+		// on both the file-picker page and the cropper page.
 		if (this.dialog && this.show_remove_bg) {
 			this.add_footer_toggle(
 				"remove_bg",
@@ -160,6 +163,26 @@ export default class FileUploader {
 				has_config && this.watermark_settings.enabled ? true : false,
 				has_config ? null : __("Click to configure watermark"),
 				has_config ? null : "/app/watermark-settings",
+			);
+		}
+		if (this.dialog && this.show_comments) {
+			this.add_footer_toggle(
+				"comments",
+				__("Comments"),
+				"comments_enabled_default",
+				!!(this.comment_defaults && this.comment_defaults.enabled),
+				null,
+				null,
+			);
+		}
+		if (this.dialog && this.show_resize) {
+			this.add_footer_toggle(
+				"canvas",
+				__("Canvas"),
+				"resize_enabled_default",
+				!!(this.resize_settings && this.resize_settings.resize_enabled),
+				null,
+				null,
 			);
 		}
 	}

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -204,6 +204,8 @@ export default class FileUploader {
 		});
 
 		this.wrapper = this.dialog.body;
+		// Tag the dialog so CSS can size it larger for the image features.
+		this.dialog.$wrapper.addClass("file-uploader-dialog");
 		this.dialog.show();
 		this.dialog.$wrapper.on("hidden.bs.modal", function () {
 			$(this).data("bs.modal", null);

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -28,6 +28,9 @@ export default class FileUploader {
 		watermark_settings,
 		show_resize,
 		resize_settings,
+		show_comments,
+		comment_defaults,
+		comment_presets,
 	} = {}) {
 		frm && frm.attachments.max_reached(true);
 		this.show_remove_bg = show_remove_bg;
@@ -38,6 +41,9 @@ export default class FileUploader {
 		this.watermark_settings = watermark_settings;
 		this.show_resize = show_resize;
 		this.resize_settings = resize_settings;
+		this.show_comments = show_comments;
+		this.comment_defaults = comment_defaults;
+		this.comment_presets = comment_presets;
 
 		if (!wrapper) {
 			this.make_dialog(dialog_title);
@@ -72,6 +78,9 @@ export default class FileUploader {
 						watermark_settings,
 						show_resize,
 						resize_settings,
+						show_comments,
+						comment_defaults,
+						comment_presets,
 					},
 				}),
 		});

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -26,6 +26,8 @@ export default class FileUploader {
 		remove_bg_padding_pct,
 		show_watermark,
 		watermark_settings,
+		show_resize,
+		resize_settings,
 	} = {}) {
 		frm && frm.attachments.max_reached(true);
 		this.show_remove_bg = show_remove_bg;
@@ -34,6 +36,8 @@ export default class FileUploader {
 		this.remove_bg_padding_pct = remove_bg_padding_pct;
 		this.show_watermark = show_watermark;
 		this.watermark_settings = watermark_settings;
+		this.show_resize = show_resize;
+		this.resize_settings = resize_settings;
 
 		if (!wrapper) {
 			this.make_dialog(dialog_title);
@@ -66,6 +70,8 @@ export default class FileUploader {
 						remove_bg_padding_pct,
 						show_watermark,
 						watermark_settings,
+						show_resize,
+						resize_settings,
 					},
 				}),
 		});

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -63,7 +63,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	on_attach_doc_image() {
 		this.set_upload_options();
 		this.upload_options.restrictions.allowed_file_types = ["image/*"];
-		this.upload_options.restrictions.crop_image_aspect_ratio = 1;
 		this.file_uploader = new frappe.ui.FileUploader(this.upload_options);
 	}
 	set_upload_options() {

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -2,6 +2,37 @@
 // MIT License. See license.txt
 
 import FileUploader from "./file_uploader";
+import ElImage from "element-ui/lib/image";
 
 frappe.provide("frappe.ui");
 frappe.ui.FileUploader = FileUploader;
+
+// Register Element UI's <el-image> on the GLOBAL Vue so any component
+// mounted through Frappe's upload flow (ImageCropper etc.) can render
+// <el-image :preview-src-list="[url]"> — el-image itself lazy-mounts
+// its internal el-image-viewer when the user clicks, so we don't need
+// to import the viewer separately. element-ui resolves via esbuild's
+// NODE_PATHS (apps/*/node_modules), which picks it up from the next
+// app where it's a direct dependency. Duplicate registrations from
+// later bundles (item_image_batch.bundle) are no-ops thanks to the
+// exists-check below.
+if (typeof window !== "undefined" && window.Vue) {
+	if (!window.Vue.component("ElImage")) {
+		window.Vue.component("ElImage", ElImage);
+	}
+}
+
+// Load Element UI's theme-chalk CSS from CDN so <el-image> and its
+// image-viewer render with the proper chrome (close button, prev/next
+// arrows, zoom/rotate toolbar, icon font). The Next/POSB/Packing List
+// modules do the same thing; the upload dialog needs it because the
+// Item form doesn't load any of those bundles. Guarded so duplicate
+// <link> tags don't accumulate across page transitions.
+if (typeof document !== "undefined"
+	&& !document.getElementById("frappe-element-ui-theme")) {
+	const link = document.createElement("link");
+	link.id = "frappe-element-ui-theme";
+	link.rel = "stylesheet";
+	link.href = "https://unpkg.com/element-ui/lib/theme-chalk/index.css";
+	document.head.appendChild(link);
+}


### PR DESCRIPTION
## Summary

Replaces the standalone **Canvas / Output Shape normalization** step with a more WYSIWYG model where the **crop box itself owns the output aspect**, plus a live **Solid Background** toggle + colour picker. The old post-crop second-pass aspect normalization (with surprise white bars) is gone; what the user sees in the workspace is what gets saved.

Companion PR: **pps190/next#502** — schema, patches, server pipeline, and Playwright E2E live there. **This PR only covers the Frappe file-uploader + Attach Image side.**

## Why

The Canvas tab shipped as a post-crop "stretch / pad / flatten to this aspect" step. Users would hand-tune a tight crop box around a product, click Crop, and be confused when the final file had white bars on top and bottom. Photoshop / Figma / every industry tool treats aspect as a property of the crop rect itself — you can see what you're keeping. The refactor matches that model.

A secondary pass also picked up the **persistence** bugs: reopening the cropper from Step 3 dropped the user's watermark slider edits, comment-box edits, crop rect + zoom, and the new aspect/solid-bg/colour values back to defaults. All fixed here.

## What changed

### Crop toolbar (ImageCropper.vue)
- **Crop ratio** button group (1:1 / 4:3 / 16:9 / Free), seeded from Image Processing Settings. Clicking reshapes the CropperJS crop box around its centre. With a Remove BG bbox active, switching aspect re-runs auto-crop expanded to the new ratio, then auto-zooms the workspace so the rect fills ~76% of the stage.
- **Solid bg** checkbox + always-visible colour picker. On → workspace backdrop live-replaces CropperJS's checkerboard with the chosen colour + output flattens alpha onto that colour. Off → checkerboard + RGBA PNG.
- **Reset** + **Save as Default** pair. Save writes all three values to IPS in one round trip then refetches the settings cache (no page reload needed). Reset snaps locally back to the saved defaults (no server write).
- Deleted: the Canvas tab / pane, `_apply_output_shape`, `_maybe_flatten`, `_reset_canvas_defaults`, `_save_canvas_defaults`, plus the Step 1 Canvas pane in FileUploader.vue and the `show_resize` / `resize_settings` / `resize_default_enabled` prop chain.

### Output format
Always PNG now. Solid bg on → RGB PNG (flatten). Off → RGBA PNG. No more JPEG output path from the client. Filename composition fixed too — suffix logic composes `stem + _nobg? + _wm? + _bg? + .png` once instead of three serial `.replace()` calls that kept eating previous suffixes.

### Persistence (Step 2 ↔ Step 3)
`crop_image()` emits a full snapshot on `crop_committed` now — watermark_state (all tile / corner params), comment_boxes (deep-cloned), crop_aspect, solid_background, background_color. FileUploader merges these into local mirrors (`local_watermark_settings`, `step1_comment_boxes`, `local_crop_aspect`, etc.) which feed ImageCropper's `default_*` props on next mount. Remove BG padding override persists via `file._padding_pct_override`.

### Attach Image control
`on_attach_doc_image()` no longer forces `crop_image_aspect_ratio = 1` — aspect comes from the remembered default so Item.image uploads honour the user's preference instead of silently locking to square.

### Mobile layout
- `.cropper-image-stage` gets `min-height: max(400px, 55vh)` with `!important` @ ≤900px and `max(400px, 50vh)` @ ≤480px. Old setup collapsed the stage to ~60px on phones.
- Whole modal-body scrolls as one unit below 900px (dropped the `max-height: calc(100vh - 180px)` cap) instead of an independent param-panel scroll region.
- `.cropper-top-toolbar` already flex-wraps, just tuned gaps and added contrast for the Solid bg pill (hover + `:has(input:checked)` active states).

### Bugs fixed along the way
- `.el-image-viewer__mask` z-index was floating above the canvas → 50% black overlay on every preview lightbox image. Removed the override (default DOM order already puts image on top of mask).
- `closest(".file-uploader .modal-body")` had the ancestry backwards — DOM is `.modal-body > .file-uploader`, not the reverse — so the sticky-footer + hidden-modal-footer + mobile-whole-body-scroll CSS was silently never applying. Fixed to `closest(".modal-body")` then confirm `.file-uploader` is a descendant.

## Test plan

- [x] Fresh Item upload: toolbar seeds from Settings
- [x] Each ratio button (1:1 / 4:3 / 16:9 / Free) reshapes CropperJS rect correctly
- [x] Solid bg toggle flips workspace backdrop live
- [x] Save as Default writes DB + refetches cache; next upload opens with new defaults
- [x] Reset reverts local state; no network request fires
- [x] Remove BG + padding slider + aspect change recompose correctly with auto-zoom
- [x] Crop → Back → Crop restores watermark sliders + comment boxes + crop values
- [x] Output is always `image/png`; Solid bg on yields `_bg` suffix
- [x] @ 390×844 (iPhone) and 744×1133 (iPad): stage ≥ 400px, body scrolls as one unit, toolbar wraps

All covered by the 16 Playwright specs in pps190/next#502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)